### PR TITLE
Implement HubL specific operators

### DIFF
--- a/parser/src/hubl-compat.js
+++ b/parser/src/hubl-compat.js
@@ -21,6 +21,7 @@ function installCompat(env) {
   var orig_Parser_parseStatement;
   var orig_Parser_parseOr;
   var orig_Parser_parseFilter;
+  var orig_Parser_parseAnd;
   if (Compiler) {
     orig_Compiler_assertType = Compiler.prototype.assertType;
   }
@@ -30,6 +31,7 @@ function installCompat(env) {
     orig_Parser_parseStatement = Parser.prototype.parseStatement;
     orig_Parser_parseOr = Parser.prototype.parseOr;
     orig_Parser_parseFilter = Parser.prototype.parseFilter;
+    orig_Parser_parseAnd = Parser.prototype.parseAnd;
   }
 
   function uninstall() {
@@ -44,6 +46,7 @@ function installCompat(env) {
       Parser.prototype.parseStatement = orig_Parser_parseStatement;
       Parser.prototype.parseOr = orig_Parser_parseOr;
       Parser.prototype.parseFilter = orig_Parser_parseFilter;
+      Parser.prototype.parseAnd = orig_Parser_parseAnd;
     }
   }
 
@@ -185,6 +188,15 @@ function installCompat(env) {
         }
         return new nodes.Array(tok.lineno, tok.colno, [node]);
       }
+    };
+
+    Parser.prototype.parseAnd = function parseAnd() {
+      let node = this.parseNot();
+      while (this.skipSymbol("&&") || this.skipSymbol("and")) {
+        const node2 = this.parseNot();
+        node = new nodes.And(node.lineno, node.colno, node, node2);
+      }
+      return node;
     };
 
     Parser.prototype.parseUnless = function parseUnless() {

--- a/parser/src/hubl-compat.js
+++ b/parser/src/hubl-compat.js
@@ -195,6 +195,7 @@ function installCompat(env) {
 
     Parser.prototype.parseAnd = function parseAnd() {
       let node = this.parseNot();
+      // Adds a check for the && symbol
       while (this.skipSymbol("&&") || this.skipSymbol("and")) {
         const node2 = this.parseNot();
         node = new nodes.And(node.lineno, node.colno, node, node2);
@@ -204,7 +205,7 @@ function installCompat(env) {
 
     Parser.prototype.parseNot = function parseNot() {
       const tok = this.peekToken();
-
+      // Add a check for the ! token
       if (this.skipValue(lexer.TOKEN_OPERATOR, "!") || this.skipSymbol("not")) {
         return new nodes.Not(tok.lineno, tok.colno, this.parseNot());
       }
@@ -318,6 +319,7 @@ function installCompat(env) {
       let node = this.parseAnd();
 
       while (
+        // Adds a check for the PIPE token followed by another PIPE char
         (this.skip(lexer.TOKEN_PIPE) && this.tokens._extractString("|")) ||
         this.skipSymbol("or")
       ) {
@@ -329,7 +331,7 @@ function installCompat(env) {
 
     Parser.prototype.parseFilter = function parseFilter(node) {
       while (this.skip(lexer.TOKEN_PIPE)) {
-        // If we encounter ||, this is not a filter
+        // If we encounter ||, this is not a filter so back out and return node
         if (this.tokens._extractString("|")) {
           this.tokens.backN(2);
           return node;
@@ -346,7 +348,6 @@ function installCompat(env) {
             [node].concat(this.parseFilterArgs(node))
           )
         );
-        // }
       }
 
       return node;

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -1328,7 +1328,7 @@ exports[`misc.html 1`] = `
 Clouds
 {% endif %}
 
-{% if sun === True and rain === 'yes' %}
+{% if sun === True && rain === 'yes' %}
 Sun Shower
 {% elif sun === true and rain === 'no' %}
 Sunny
@@ -1450,6 +1450,16 @@ Infinity
 {{ rel|join(" ") }}
 
 {% set testing_table_id = null %} 
+
+{% unless true %}
+  Content
+{% endunless %}
+
+{% unless (module.logo.link is string_startingwith("http")) || (module.logo.link is string_startingwith("/")) or (module.logo.link is string_startingwith("mailto")) or (module.logo.link is string_startingwith("#")) or (not module.logo.link) %}
+    {% set link = "//" ~ module.logo.link %}
+  {% else %}
+    {% set link = module.logo.link || "" %}
+  {% endunless %}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {% if sky === "blue" %}
   Clouds
@@ -1588,6 +1598,16 @@ Infinity
 {{ rel|join(" ") }}
 
 {% set testing_table_id = null %}
+
+{% unless true %}
+  Content
+{% endunless %}
+
+{% unless (module.logo.link is string_startingwith("http")) or (module.logo.link is string_startingwith("/")) or (module.logo.link is string_startingwith("mailto")) or (module.logo.link is string_startingwith("#")) or (not module.logo.link) %}
+  {% set link = "//" ~ module.logo.link %}
+{% else %}
+  {% set link = module.logo.link or "" %}
+{% endunless %}
 
 `;
 

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -1324,7 +1324,7 @@ exports[`minimal_nested.html 1`] = `
 `;
 
 exports[`misc.html 1`] = `
-{% if sky === 'blue' %}
+{% if sky != 'blue' %}
 Clouds
 {% endif %}
 
@@ -1342,9 +1342,9 @@ Sledding
 Brrrr
 {% endif %}
 
-{% if one %}
+{% if !one %}
 One
-{% elif two %}
+{% elif not two %}
 Two
 {% elif three %}
 Three
@@ -1361,7 +1361,7 @@ Infinity
 {% endif %}
 
 {% if true %}
-  {% if false %}
+  {% if !false %}
 
   {% endif %}
   {% endif %}
@@ -1461,7 +1461,7 @@ Infinity
     {% set link = module.logo.link || "" %}
   {% endunless %}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-{% if sky === "blue" %}
+{% if sky != "blue" %}
   Clouds
 {% endif %}
 
@@ -1479,9 +1479,9 @@ Infinity
   Brrrr
 {% endif %}
 
-{% if one %}
+{% if not one %}
   One
-{% elif two %}
+{% elif not two %}
   Two
 {% elif three %}
   Three
@@ -1509,7 +1509,7 @@ Infinity
 {% endif %}
 
 {% if true %}
-  {% if false %}
+  {% if not false %}
 
   {% endif %}
 {% endif %}

--- a/prettier/tests/misc.html
+++ b/prettier/tests/misc.html
@@ -2,7 +2,7 @@
 Clouds
 {% endif %}
 
-{% if sun === True and rain === 'yes' %}
+{% if sun === True && rain === 'yes' %}
 Sun Shower
 {% elif sun === true and rain === 'no' %}
 Sunny

--- a/prettier/tests/misc.html
+++ b/prettier/tests/misc.html
@@ -1,4 +1,4 @@
-{% if sky === 'blue' %}
+{% if sky != 'blue' %}
 Clouds
 {% endif %}
 
@@ -16,9 +16,9 @@ Sledding
 Brrrr
 {% endif %}
 
-{% if one %}
+{% if !one %}
 One
-{% elif two %}
+{% elif not two %}
 Two
 {% elif three %}
 Three
@@ -35,7 +35,7 @@ Infinity
 {% endif %}
 
 {% if true %}
-  {% if false %}
+  {% if !false %}
 
   {% endif %}
   {% endif %}

--- a/prettier/tests/misc.html
+++ b/prettier/tests/misc.html
@@ -129,8 +129,8 @@ Infinity
   Content
 {% endunless %}
 
-{% unless (module.logo.link is string_startingwith("http")) or (module.logo.link is string_startingwith("/")) or (module.logo.link is string_startingwith("mailto")) or (module.logo.link is string_startingwith("#")) or (not module.logo.link) %}
+{% unless (module.logo.link is string_startingwith("http")) || (module.logo.link is string_startingwith("/")) or (module.logo.link is string_startingwith("mailto")) or (module.logo.link is string_startingwith("#")) or (not module.logo.link) %}
     {% set link = "//" ~ module.logo.link %}
   {% else %}
-    {% set link = module.logo.link or "" %}
+    {% set link = module.logo.link || "" %}
   {% endunless %}


### PR DESCRIPTION
Custom implementations of existing operator parsers added to the `hubl-compat` plugin:
- [x] ||
- [x] &&
- [x] !

The current approach will replace these operators with the Jinja style operator. For example:
`{{ this || that }}` will become `{{ this or that }}`

Fixes #10 