### PR TITLE
Handle built in tests

### DIFF
--- a/parser/src/hubl-compat.js
+++ b/parser/src/hubl-compat.js
@@ -55,7 +55,8 @@ function installCompat(env) {
       Parser.prototype.parsePostfix = orig_Parse_parsePostfix;
     }
   }
-  const tests = [
+
+  const builtInTests = [
     "divisibleby",
     "equalto",
     "eq",
@@ -315,8 +316,7 @@ function installCompat(env) {
           lookup = new nodes.Literal(val.lineno, val.colno, val.value);
 
           node = new nodes.LookupVal(tok.lineno, tok.colno, node, lookup);
-        } else if (node && tests.includes(node.value)) {
-          console.log(node.value);
+        } else if (node && builtInTests.includes(node.value)) {
           node = new nodes.FunCall(
             tok.lineno,
             tok.colno,

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -316,6 +316,13 @@ function printHubl(node) {
         group([`{% endmacro %}`]),
       ];
     case "Not":
+      if (node.target.typename === "Is") {
+        return [
+          printHubl(node.target.left),
+          " is not ",
+          printHubl(node.target.right),
+        ];
+      }
       return ["not ", printHubl(node.target)];
     case "Group":
       return group([

--- a/prettier/tests/misc.html
+++ b/prettier/tests/misc.html
@@ -139,3 +139,15 @@ Infinity
 <{{ module.list_type }} class="list">
 What is this element?
 </{{ module.list_type }}>
+
+{{ foo is equalto "bar" }}
+{{ foo is equalto("bar") }}
+
+{{ foo is equalto var }}
+{{ foo is equalto(var) }}
+
+{{ foo is not equalto "baz" }}
+{{ foo is not equalto("baz") }}
+
+{% if var is string_startingwith "v" %}{% endif %}
+{% if var is string_startingwith("v") %}{% endif %}


### PR DESCRIPTION
Fixes known issue where "is tests" are only supported with parens:

`{{ foo is string_containg bar }} --> {{ foo is string_containg(bar) }}`
