### PR TITLE
Skip trailing commas in Dicts

### DIFF
--- a/parser/src/parser/parser.js
+++ b/parser/src/parser/parser.js
@@ -1340,6 +1340,12 @@ class Parser extends Obj {
       }
 
       if (node instanceof nodes.Dict) {
+        // If the last item in a Dictionary is followed by a trailing comma, skip it
+        if (this.peekToken().type === lexer.TOKEN_RIGHT_CURLY) {
+          this.nextToken();
+          break;
+        }
+
         // TODO: check for errors
         const key = this.parsePrimary();
 

--- a/prettier/tests/home.html
+++ b/prettier/tests/home.html
@@ -37,7 +37,7 @@
     "max_height": 451,
     "max_width": 605,
     "size_type": "auto_custom_max",
-    "src": get_asset_url("../images/grayscale-mountain.png")
+    "src": get_asset_url("../images/grayscale-mountain.png"),
   },
   offset=0,
   width=6
@@ -47,7 +47,7 @@
   path="@hubspot/rich_text",
   html="<h2>Provide more details here.</h2><p>Use text and images to tell your company’s story. Explain what makes your product or service extraordinary.</p>"
   offset=6,
-  width=6
+  width=6,
 %}
     {% end_dnd_module %}
   {% end_dnd_section %}

--- a/prettier/tests/qatest.html
+++ b/prettier/tests/qatest.html
@@ -164,7 +164,7 @@
       %}
         {% dnd_module path="@hubspot/form",
           offset=0,
-          width=4
+          width=4,
         %}
         {% end_dnd_module %}
         {% dnd_module path="@hubspot/form",
@@ -198,7 +198,7 @@
 
       {% dnd_row
         margin={
-          "top": 35
+          "top": 35,
         }
       %}
         {% dnd_module path="@hubspot/rich_text" %}

--- a/prettier/tests/set.html
+++ b/prettier/tests/set.html
@@ -25,7 +25,7 @@ a_var %}
         html={{ context.heading or '<div style="text-align: center;"><h1>Pricing</h1></div>' }},
         no="yes",
  margin={
-          "top": 35
+          "top": 35,
         },
         false=true
       %} 


### PR DESCRIPTION
If the last item in a dict is followed by a trailing comma, it was throwing and error. With this change, the parser will skip right over the comma and the comma will not get printed