### PR TITLE
refactor logic around String.replaceAll()

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "foreman": "^3.0.1"
   },
   "engines": {
-    "node": ">=15"
+    "node": ">=12"
   },
   "scripts": {
     "start": "nf start -j ./configuration/watch-all",

--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -121,19 +121,24 @@ const tokenize = (input) => {
 };
 const unTokenize = (input) => {
   tokenMap.forEach((value, key) => {
-    // HTML formatter sometimes adds a space after the placeholder comment so we check for it and remove if it exists
+    // Placeholders in styleblocks need special treatment
     if (key.startsWith("/*styleblock")) {
-      const STYLEBLOCK_WITH_SPACE_PATTERN = `${key.replace(
-        /[-\/\\^$*+?.()|[\]{}]/g,
-        "\\$&"
-      )}\\s;`;
-      const STYLEBLOCK_REGEX = new RegExp(STYLEBLOCK_WITH_SPACE_PATTERN, "gm");
+      // The CSS comment needs to be escaped
+      const newKey = key.replace(/\//g, "\\/").replace(/\*/g, "\\*");
+      const STYLEBLOCK_REGEX = new RegExp(
+        `${key.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")}\\s;`,
+        "gm"
+      );
+      // HTML formatter sometimes adds a space after the placeholder comment so we check for it and remove if it exists
       if (STYLEBLOCK_REGEX.test(input)) {
-        input = input.replace(key + " ;", value + ";");
+        input = input.replace(new RegExp(newKey + " ;", "g"), value + ";");
+        return;
+      } else {
+        input = input.replace(new RegExp(newKey, "g"), value);
         return;
       }
     }
-    input = input.replaceAll(key, value);
+    input = input.replace(new RegExp(key, "g"), value);
   });
   tokenMap.clear();
 

--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -124,17 +124,17 @@ const unTokenize = (input) => {
     // Placeholders in styleblocks need special treatment
     if (key.startsWith("/*styleblock")) {
       // The CSS comment needs to be escaped
-      const newKey = key.replace(/\//g, "\\/").replace(/\*/g, "\\*");
+      const escapedKey = key.replace(/\//g, "\\/").replace(/\*/g, "\\*");
       const STYLEBLOCK_REGEX = new RegExp(
         `${key.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")}\\s;`,
         "gm"
       );
       // HTML formatter sometimes adds a space after the placeholder comment so we check for it and remove if it exists
       if (STYLEBLOCK_REGEX.test(input)) {
-        input = input.replace(new RegExp(newKey + " ;", "g"), value + ";");
+        input = input.replace(new RegExp(escapedKey + " ;", "g"), value + ";");
         return;
       } else {
-        input = input.replace(new RegExp(newKey, "g"), value);
+        input = input.replace(new RegExp(escapedKey, "g"), value);
         return;
       }
     }


### PR DESCRIPTION
This PR refactors away from `String.replaceAll()`, which was only introduced in node 15 and adds support back to at node 12 (earliest tested)