### PR TITLE
Full comment support

### DIFF
--- a/parser/src/parser/nodes.js
+++ b/parser/src/parser/nodes.js
@@ -83,6 +83,7 @@ class NodeList extends Node {
   }
 }
 
+const Comment = Value.extend("Comment");
 const Root = NodeList.extend("Root");
 const Literal = Value.extend("Literal");
 const Symbol = Value.extend("Symbol");
@@ -294,6 +295,6 @@ module.exports = {
 
   CallExtension: CallExtension,
   CallExtensionAsync: CallExtensionAsync,
-
+  Comment: Comment,
   printNodes: printNodes,
 };

--- a/parser/src/parser/parser.js
+++ b/parser/src/parser/parser.js
@@ -1467,10 +1467,11 @@ class Parser extends Obj {
         variableNode.whiteSpace.openTag.end = this.dropLeadingWhitespace;
         buf.push(variableNode);
       } else if (tok.type === lexer.TOKEN_COMMENT) {
-        this.dropLeadingWhitespace =
-          tok.value.charAt(
-            tok.value.length - this.tokens.tags.COMMENT_END.length - 1
-          ) === "-";
+        this.dropLeadingWhitespace = false;
+        // Instead of parsing out the delimiters, we're going to capture
+        // the entire comment, delimeters and all
+        const commentNode = new nodes.Comment(tok.lineno, tok.colno, tok.value);
+        buf.push(commentNode);
       } else {
         // Ignore comments, otherwise this should be an error
         this.fail(

--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -142,10 +142,6 @@ const unTokenize = (input) => {
   });
   tokenMap.clear();
 
-  const COMMENT_START_REGEX = /{#/gm;
-  const COMMENT_END_REGEX = /#}/gm;
-  input = input.replace(COMMENT_START_REGEX, "{% comment %}<!--");
-  input = input.replace(COMMENT_END_REGEX, "-->{% end_comment %}");
   return input;
 };
 

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -277,6 +277,8 @@ function printHubl(node) {
         return util.makeString(node.value, '"');
       }
       return `${node.value}`;
+    case "Comment":
+      return node.value;
     case "Filter":
       const leftHandSide = node.args.children.shift();
       const parts = [printHubl(leftHandSide), "|", printHubl(node.name)];

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -451,6 +451,34 @@ screenshotPath: ../images/template-previews/blog-post.png
 
 `;
 
+exports[`comments.html 1`] = `
+<div>
+  {# A comment #}
+</div>
+
+<img src="">{# a trailing comment #}
+
+<img src=""> {# a trailing comment that should wrap #}
+
+{% block head -%}
+{# A comment with whitespace control -#}
+{%- endblock -%}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div>
+  {# A comment #}
+</div>
+
+<img src="" />{# a trailing comment #}
+
+<img src="" />
+{# a trailing comment that should wrap #}
+
+{% block head -%}
+  {# A comment with whitespace control -#}
+{%- endblock head -%}
+
+`;
+
 exports[`complex.html 1`] = `
 <!--
 templateType: none

--- a/prettier/tests/comments.html
+++ b/prettier/tests/comments.html
@@ -1,0 +1,11 @@
+<div>
+  {# A comment #}
+</div>
+
+<img src="">{# a trailing comment #}
+
+<img src=""> {# a trailing comment that should wrap #}
+
+{% block head -%}
+{# A comment with whitespace control -#}
+{%- endblock -%}


### PR DESCRIPTION
Removed the previous comment implementation that utilized replaced strings and creates an official `Comment` node type. 

Note: comments are still place-held as HTML comments when run through the HTML parser, and will indented as such.