### PR TITLE
Add support for hubl compare operators

### DIFF
--- a/parser/src/parser/parser.js
+++ b/parser/src/parser/parser.js
@@ -920,7 +920,13 @@ class Parser extends Obj {
         lookup = new nodes.Literal(val.lineno, val.colno, val.value);
 
         node = new nodes.LookupVal(tok.lineno, tok.colno, node, lookup);
-      } else if (node && builtInTests.includes(node.value)) {
+      } else if (
+        node &&
+        builtInTests.includes(node.value) &&
+        // We only want treat these as FuncCalls if directly followed by a string or symbol
+        (this.peekToken().type === lexer.TOKEN_STRING ||
+          this.peekToken().type === lexer.TOKEN_SYMBOL)
+      ) {
         node = new nodes.FunCall(
           tok.lineno,
           tok.colno,

--- a/parser/src/parser/parser.js
+++ b/parser/src/parser/parser.js
@@ -1059,7 +1059,23 @@ class Parser extends Obj {
   }
 
   parseCompare() {
-    const compareOps = ["==", "===", "!=", "!==", "<", ">", "<=", ">="];
+    const compareOps = [
+      "==",
+      "===",
+      "!=",
+      "!==",
+      "<",
+      ">",
+      "<=",
+      ">=",
+      // HubL Specific Shorthand: https://developers.hubspot.com/docs/cms/hubl/operators-and-expression-tests#comparison
+      "eq",
+      "ne",
+      "gt",
+      "gte",
+      "lt",
+      "lte",
+    ];
     const expr = this.parseConcat();
     const ops = [];
 

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -1190,8 +1190,7 @@ exports[`json.html 1`] = `
 [{"social_account":"facebook-f", "social_account":"linkedin-f"},{"social_account":"twitter", "social_account":"instagram"}]
 {% end_module_attribute %}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-{% module_attribute "social_link"
-  is_json=True %}
+{% module_attribute "social_link" is_json=True %}
     [
       { "social_account": "facebook-f", "social_account": "linkedin-f" },
       { "social_account": "twitter", "social_account": "instagram" }
@@ -1444,7 +1443,7 @@ Infinity
           name="angle-double-left",
           purpose="decorative",
           style="SOLID",
-          unicode="f100" 
+          unicode="f100"
         %}
         <span class="pagination__link-text show-for-sr--mobile">{{ module.first_label }}</span>
       </a>
@@ -1481,7 +1480,7 @@ Infinity
         timeframe={{ context.card_one_timeframe or "/mo" }},
         width=4
       %}{% end_dnd_module %}
-      
+
 {% do rel.append("nofollow") %}
 
 {% set rel = [] %}
@@ -1511,7 +1510,7 @@ Infinity
       {% set x = true %}
       {{ variable2 }}
       </div>
-      
+
     {% endblock %}
 
 
@@ -1521,7 +1520,7 @@ Infinity
 
 {{ rel|join(" ") }}
 
-{% set testing_table_id = null %} 
+{% set testing_table_id = null %}
 
 {% unless true %}
   Content
@@ -1554,6 +1553,12 @@ What is this element?
 {{ foo % bar }}
 {{ foo ** bar }}
 {{ foo * bar }}
+{{ 1 eq 3 }}
+{{ 1 ne 3 }}
+{{ 1 gt 3 }}
+{{ 1 gte 3 }}
+{{ 1 lt 3 }}
+{{ 1 lte 3 }}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {% if sky != "blue" %}
   Clouds
@@ -1720,6 +1725,12 @@ What is this element?
 {{ foo % bar }}
 {{ foo ** bar }}
 {{ foo * bar }}
+{{ 1 eq 3 }}
+{{ 1 ne 3 }}
+{{ 1 gt 3 }}
+{{ 1 gte 3 }}
+{{ 1 lt 3 }}
+{{ 1 lte 3 }}
 
 `;
 
@@ -3805,8 +3816,7 @@ This is a simple dialog rendered by using a macro and a call block.
     loop_slides=True,
     num_seconds=5,
     version="1" %}
-    {% widget_attribute "slides"
-      is_json=True %}
+    {% widget_attribute "slides" is_json=True %}
       [
         {
           "caption": "CRM Contacts App",
@@ -4071,8 +4081,7 @@ This is a simple dialog rendered by using a macro and a call block.
     label="Social Sharing",
     use_page_url=True,
     overrideable=True %}
-    {% widget_attribute "pinterest"
-      is_json=True %}
+    {% widget_attribute "pinterest" is_json=True %}
       {
         "custom_link_format": "",
         "pinterest_media": "http://cdn2.hubspot.net/hub/158015/305390_10100548508246879_837195_59275782_6882128_n.jpg",
@@ -4081,8 +4090,7 @@ This is a simple dialog rendered by using a macro and a call block.
         "img_src": "https://static.hubspot.com/final/img/common/icons/social/pinterest-24x24.png"
       }
     {% end_widget_attribute %}
-    {% widget_attribute "twitter"
-      is_json=True %}
+    {% widget_attribute "twitter" is_json=True %}
       {
         "custom_link_format": "",
         "enabled": true,
@@ -4090,8 +4098,7 @@ This is a simple dialog rendered by using a macro and a call block.
         "img_src": "https://static.hubspot.com/final/img/common/icons/social/twitter-24x24.png"
       }
     {% end_widget_attribute %}
-    {% widget_attribute "linkedin"
-      is_json=True %}
+    {% widget_attribute "linkedin" is_json=True %}
       {
         "custom_link_format": "",
         "enabled": true,
@@ -4099,8 +4106,7 @@ This is a simple dialog rendered by using a macro and a call block.
         "img_src": "https://static.hubspot.com/final/img/common/icons/social/linkedin-24x24.png"
       }
     {% end_widget_attribute %}
-    {% widget_attribute "facebook"
-      is_json=True %}
+    {% widget_attribute "facebook" is_json=True %}
       {
         "custom_link_format": "",
         "enabled": true,
@@ -4108,8 +4114,7 @@ This is a simple dialog rendered by using a macro and a call block.
         "img_src": "https://static.hubspot.com/final/img/common/icons/social/facebook-24x24.png"
       }
     {% end_widget_attribute %}
-    {% widget_attribute "email"
-      is_json=True %}
+    {% widget_attribute "email" is_json=True %}
       {
         "custom_link_format": "",
         "enabled": true,

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -1559,6 +1559,11 @@ What is this element?
 {{ 1 gte 3 }}
 {{ 1 lt 3 }}
 {{ 1 lte 3 }}
+
+{{ var|rejectattr('slug', 'eq', content.slug) }}
+{{ var|rejectattr('slug', equalto, content.slug) }}
+
+{{ 'eq' }}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {% if sky != "blue" %}
   Clouds
@@ -1731,6 +1736,11 @@ What is this element?
 {{ 1 gte 3 }}
 {{ 1 lt 3 }}
 {{ 1 lte 3 }}
+
+{{ var|rejectattr("slug", "eq", content.slug) }}
+{{ var|rejectattr("slug", equalto, content.slug) }}
+
+{{ "eq" }}
 
 `;
 

--- a/prettier/tests/misc.html
+++ b/prettier/tests/misc.html
@@ -46,7 +46,7 @@ Infinity
           name="angle-double-left",
           purpose="decorative",
           style="SOLID",
-          unicode="f100" 
+          unicode="f100"
         %}
         <span class="pagination__link-text show-for-sr--mobile">{{ module.first_label }}</span>
       </a>
@@ -83,7 +83,7 @@ Infinity
         timeframe={{ context.card_one_timeframe or "/mo" }},
         width=4
       %}{% end_dnd_module %}
-      
+
 {% do rel.append("nofollow") %}
 
 {% set rel = [] %}
@@ -113,7 +113,7 @@ Infinity
       {% set x = true %}
       {{ variable2 }}
       </div>
-      
+
     {% endblock %}
 
 
@@ -123,7 +123,7 @@ Infinity
 
 {{ rel|join(" ") }}
 
-{% set testing_table_id = null %} 
+{% set testing_table_id = null %}
 
 {% unless true %}
   Content
@@ -156,3 +156,9 @@ What is this element?
 {{ foo % bar }}
 {{ foo ** bar }}
 {{ foo * bar }}
+{{ 1 eq 3 }}
+{{ 1 ne 3 }}
+{{ 1 gt 3 }}
+{{ 1 gte 3 }}
+{{ 1 lt 3 }}
+{{ 1 lte 3 }}

--- a/prettier/tests/misc.html
+++ b/prettier/tests/misc.html
@@ -162,3 +162,8 @@ What is this element?
 {{ 1 gte 3 }}
 {{ 1 lt 3 }}
 {{ 1 lte 3 }}
+
+{{ var|rejectattr('slug', 'eq', content.slug) }}
+{{ var|rejectattr('slug', equalto, content.slug) }}
+
+{{ 'eq' }}


### PR DESCRIPTION
Adds support for [HubL shorthand operators](https://developers.hubspot.com/docs/cms/hubl/operators-and-expression-tests#comparison)

Also fixes an issue where any of the `builtinTests` would throw an error if used as a string/symbol outside of being the name of a function like `{{ var|rejectattr('slug', equalto, content.slug) }}`

Fixes #51 