### PR TITLE
Use bracket & quote syntax if lookup value contains hyphen

### DIFF
--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -262,7 +262,8 @@ function printHubl(node) {
     case "LookupVal":
       if (
         node.val.typename === "Literal" &&
-        typeof node.val.value === "string"
+        typeof node.val.value === "string" &&
+        !node.val.value.includes("-")
       ) {
         return [printHubl(node.target), ".", node.val.value];
       }

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -1567,6 +1567,11 @@ What is this element?
 
 {{ variable[1] }}
 {{ variable[2] }}
+
+{{ variable['one'] }}
+{{ variable1.variable2['one'] }}
+{{ variable['two-words'] }}
+{{ variable1.variable2['two-words'] }}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {% if sky != "blue" %}
   Clouds
@@ -1747,6 +1752,11 @@ What is this element?
 
 {{ variable[1] }}
 {{ variable[2] }}
+
+{{ variable.one }}
+{{ variable1.variable2.one }}
+{{ variable["two-words"] }}
+{{ variable1.variable2["two-words"] }}
 
 `;
 

--- a/prettier/tests/misc.html
+++ b/prettier/tests/misc.html
@@ -170,3 +170,8 @@ What is this element?
 
 {{ variable[1] }}
 {{ variable[2] }}
+
+{{ variable['one'] }}
+{{ variable1.variable2['one'] }}
+{{ variable['two-words'] }}
+{{ variable1.variable2['two-words'] }}


### PR DESCRIPTION
`{{ variable1.variable2["two-words"] }}`

was incorrectly getting formatted as 

`{{ variable1.variable2.two-words }}`

and on subsequent formats, would format as 

`{{ variable1.variable2.two - words }}`