### PR TITLE
Check for valid name before reformatting bracket notation to use dots

### DIFF
--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -28,6 +28,9 @@ const closeVar = (whitespace) => {
   return whitespace.end ? "-}}" : "}}";
 };
 
+const isValidVariable = (testString: string) =>
+  /^[a-zA-Z_$][0-9a-zA-Z_$]*$/gm.test(testString);
+
 // Recurvisely print if elif and else
 const printElse = (node) => {
   if (node.else_ && node.else_.typename === "If") {
@@ -275,7 +278,7 @@ function printHubl(node) {
       if (
         node.val.typename === "Literal" &&
         typeof node.val.value === "string" &&
-        !node.val.value.includes("-")
+        isValidVariable(node.val.value)
       ) {
         return [printHubl(node.target), ".", node.val.value];
       }

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -448,6 +448,36 @@ screenshotPath: ../images/template-previews/blog-post.png
 
 `;
 
+exports[`brackets.html 1`] = `
+{% set test_object = {
+    "foo bar": "baz",
+    "another test value": "blah",
+    "a-hyphen": "test",
+    "shouldBeDotted": "test",
+    "should_Be_Dotted": "test"
+}%}
+{{ test_object["foo bar"] }}
+{{ test_object["another test value"] }}
+{{ test_object["a-hyphen"] }}
+{{ test_object["shouldBeDotted"] }}
+{{ test_object["should_Be_Dotted"] }}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% set test_object = {
+  "foo bar": "baz",
+  "another test value": "blah",
+  "a-hyphen": "test",
+  "shouldBeDotted": "test",
+  "should_Be_Dotted": "test"
+} %}
+{{ test_object["foo bar"] }}
+{{ test_object["another test value"] }}
+{{ test_object["a-hyphen"] }}
+{{ test_object.shouldBeDotted }}
+{{ test_object.should_Be_Dotted }}
+
+`;
+
 exports[`comments.html 1`] = `
 <div>
   {# A comment #}

--- a/prettier/tests/brackets.html
+++ b/prettier/tests/brackets.html
@@ -1,0 +1,13 @@
+{% set test_object = {
+    "foo bar": "baz",
+    "another test value": "blah",
+    "a-hyphen": "test",
+    "shouldBeDotted": "test",
+    "should_Be_Dotted": "test"
+}%}
+{{ test_object["foo bar"] }}
+{{ test_object["another test value"] }}
+{{ test_object["a-hyphen"] }}
+{{ test_object["shouldBeDotted"] }}
+{{ test_object["should_Be_Dotted"] }}
+


### PR DESCRIPTION
Closes #70 (and maybe #68) by checking that the bracketed name can be converted to a dot notation before doing it. Otherwise just uses regular brackets. The regex here is ` /^[a-zA-Z_$][0-9a-zA-Z_$]*$/` which roughly should match any valid Javascript variable, which should cover valid HubL variable names as well. See updated snapshot for updated behaviour.