### PR TITLE
Jb/workspace adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "main": "./prettier/dist/src/index.js",
   "type": "module",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "@prettier/sync": "^0.5.2",
+    "hubl-parser": "1.0.0"
+  },
   "peerDependencies": {
     "prettier": "3.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/prettier-plugin-hubl",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "main": "./prettier/dist/src/index.js",
   "type": "module",
   "private": false,
@@ -36,7 +36,8 @@
     "build:parser": "yarn run:parser build",
     "build": "(yarn run build:parser) && (yarn run build:prettier)",
     "npm:publish-beta": "npm publish . --tag beta",
-    "npm:publish-latest": "npm publish . --tag latest"
+    "npm:publish-latest": "npm publish . --tag latest",
+    "npm:publish-experimental": "npm publish . --tag experimental"
   },
   "files": [
     "prettier/dist/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "root",
+  "name": "@hubspot/prettier-plugin-hubl",
   "version": "0.3.0",
   "main": "./prettier/dist/src/index.js",
+  "type": "module",
   "private": true,
   "dependencies": {},
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@hubspot/prettier-plugin-hubl",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "main": "./prettier/dist/src/index.js",
   "type": "module",
-  "private": true,
+  "private": false,
   "dependencies": {
     "@prettier/sync": "^0.5.2",
     "hubl-parser": "1.0.0"
@@ -19,9 +19,7 @@
     "eslint": "^8.35.0"
   },
   "bundledDependencies": [
-    "@prettier/sync",
-    "hubl-parser",
-    "prettier"
+    "hubl-parser"
   ],
   "engines": {
     "node": ">=16"
@@ -41,8 +39,8 @@
     "npm:publish-latest": "npm publish . --tag latest"
   },
   "files": [
-    "parser/dist",
-    "prettier/dist"
+    "prettier/dist/src",
+    "!prettier/dist/tests/**"
   ],
   "workspaces": [
     "parser",
@@ -50,7 +48,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:HubSpot/prettier-plugin-hubl.git"
+    "url": "git+ssh://git@github.com/HubSpot/prettier-plugin-hubl.git"
   },
   "author": "HubSpot, Inc.",
   "license": "Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "@typescript-eslint/parser": "^5.59.7",
     "eslint": "^8.35.0"
   },
+  "bundledDependencies": [
+    "@prettier/sync",
+    "hubl-parser",
+    "prettier"
+  ],
   "engines": {
     "node": ">=16"
   },

--- a/prettier/package.json
+++ b/prettier/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hubspot/prettier-plugin-hubl",
-  "version": "0.3.0",
+  "name": "prettier-printer-hubl",
+  "version": "1.1.0",
   "description": "",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
@TanyaScales This seems to take care of it. 

Things to note with testing. I'm was seeing a lot of what seemed like cached files when trying to re-install `npm pack` ed bundles. Deleting those files or at least verifying my changes where there when I installed helped.

This bubbles up dependencies from the workspaced files, and `bundledDependencies` makes sure that they're included in the package.