### PR TITLE
fix: {% set %} block capture syntax not rendering the body

### DIFF
--- a/parser/src/parser/parser.js
+++ b/parser/src/parser/parser.js
@@ -645,20 +645,22 @@ export class Parser extends Obj {
           tag.colno,
         );
       } else {
+        node.whiteSpace.openTag.end = this.dropLeadingWhitespace;
         node.body = new nodes.Capture(
           tag.lineno,
           tag.colno,
           this.parseUntilBlocks("endset"),
         );
+        node.whiteSpace.closingTag.start = this.dropLeadingWhitespace;
         node.value = null;
         this.advanceAfterBlockEnd();
+        node.whiteSpace.closingTag.end = this.dropLeadingWhitespace;
       }
     } else {
       node.value = this.parseExpression();
       this.advanceAfterBlockEnd(tag.value);
+      node.whiteSpace.openTag.end = this.dropLeadingWhitespace;
     }
-
-    node.whiteSpace.openTag.end = this.dropLeadingWhitespace;
 
     return node;
   }

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -145,21 +145,36 @@ function printHubl(node) {
       });
     case "Preserve":
       return node.value;
-    case "Set":
+    case "Set": {
+      const setTargets = join(
+        ", ",
+        node.targets.map((target) => {
+          return target.value;
+        }),
+      );
+      if (node.body) {
+        return [
+          openTag(node.whiteSpace.openTag),
+          " set ",
+          setTargets,
+          " ",
+          closeTag(node.whiteSpace.openTag),
+          indent(printBody(node.body.body)),
+          openTag(node.whiteSpace.closingTag),
+          " endset ",
+          closeTag(node.whiteSpace.closingTag),
+        ];
+      }
       return [
         openTag(node.whiteSpace.openTag),
         " set ",
-        join(
-          ", ",
-          node.targets.map((target) => {
-            return target.value;
-          }),
-        ),
+        setTargets,
         " = ",
         printHubl(node.value),
         " ",
         closeTag(node.whiteSpace.openTag),
       ];
+    }
     case "Concat":
       return [printHubl(node.left), " ~ ", printHubl(node.right)];
     case "And":

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -3269,6 +3269,24 @@ a_var %}
 {% set key, value = func_with(1, 'two', three,
  four(a,b,c,d,e)) %}
 
+{% set content %}
+  <div class="wrapper">
+    <p>Some content here</p>
+  </div>
+{% endset %}
+
+{%- set module_content -%}
+  <div class="offers-embedded-wrapper">
+    <p>Some content here</p>
+  </div>
+{%- endset -%}
+
+{% set nested_hubl %}
+  <div>{{ some_var }}</div>
+  {% if show_extra %}
+    <span>Extra</span>
+  {% endif %}
+{% endset %}
 
 <!--
   templateType: section
@@ -3302,6 +3320,25 @@ a_var %}
 {% set key, value = 123 %}
 {% set key, value = call_something() %}
 {% set key, value = func_with(1, "two", three, four(a, b, c, d, e)) %}
+
+{% set content %}
+  <div class="wrapper">
+    <p>Some content here</p>
+  </div>
+{% endset %}
+
+{%- set module_content -%}
+  <div class="offers-embedded-wrapper">
+    <p>Some content here</p>
+  </div>
+{%- endset -%}
+
+{% set nested_hubl %}
+  <div>{{ some_var }}</div>
+  {% if show_extra %}
+    <span>Extra</span>
+  {% endif %}
+{% endset %}
 
 <!--
   templateType: section

--- a/prettier/tests/set.html
+++ b/prettier/tests/set.html
@@ -9,6 +9,24 @@ a_var %}
 {% set key, value = func_with(1, 'two', three,
  four(a,b,c,d,e)) %}
 
+{% set content %}
+  <div class="wrapper">
+    <p>Some content here</p>
+  </div>
+{% endset %}
+
+{%- set module_content -%}
+  <div class="offers-embedded-wrapper">
+    <p>Some content here</p>
+  </div>
+{%- endset -%}
+
+{% set nested_hubl %}
+  <div>{{ some_var }}</div>
+  {% if show_extra %}
+    <span>Extra</span>
+  {% endif %}
+{% endset %}
 
 <!--
   templateType: section


### PR DESCRIPTION
Fixes #66

The printer always emitted the expression form `{% set x = value %}` for Set nodes, dropping the body and corrupting block capture syntax (`{% set x %}...{% endset %}`).

**Changes:**
- **Printer** (`prettier/src/printHubl.ts`): Branch on `node.body` to distinguish
  block capture from expression assignment, printing `{% set %}...{% endset %}` correctly
- **Parser** (`parser/src/parser/parser.js`): Capture `closingTag` whitespace markers
  for `{% endset %}`, matching the pattern used by all other block tags

**Before:**
`{% set content %}..{% endset %}` → `{% set content = %}`
(body dropped, invalid syntax)
**After:**
Block structure and content preserved, whitespace control (`{%- -%}`) respected.