### PR TITLE
fix: regex patterns in filters no longer crash or corrupt

### DIFF
--- a/parser/src/parser/lexer.js
+++ b/parser/src/parser/lexer.js
@@ -371,7 +371,7 @@ export class Tokenizer {
             str += "\r";
             break;
           default:
-            str += this.current();
+            str += "\\" + this.current();
         }
         this.forward();
       } else {

--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -160,7 +160,7 @@ const tokenize = (input: string): string => {
 
 const unTokenize = (input: string) => {
   tokenMap.forEach((value, key) => {
-    input = input.replaceAll(key, value);
+    input = input.replaceAll(key, () => value);
   });
   tokenMap.clear();
   return input;

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -3257,6 +3257,45 @@ exports[`formats qatest.html correctly 1`] = `
 
 `;
 
+exports[`formats regex-filters.html correctly 1`] = `
+{%- set option_lower_and_free_of_special_chars = option.name|lower|trim|replace('&', ' ')|replace('/', ' ')|regex_replace('\\\\s+', ' ') -%}
+{% set breadcrumb_schema = {
+  "breadcrumb": {
+    "itemListElement": [
+      {
+        "item": {
+          "@id": content.absolute_url|regex_replace('/[^/]*$', ''),
+          "name": module.name_offer_parent
+        }
+      }
+    ]
+  }
+} %}
+{%- set ends_with_dollar_quote = f('a$', 'b') -%}
+{%- set amp_pattern = x|regex_replace('$&', '') -%}
+{%- set back_tick_pattern = x|regex_replace("$\`", '') -%}
+{%- set backslash_replace = path|replace('\\\\', '/') -%}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{%- set option_lower_and_free_of_special_chars = option.name|lower|trim|replace("&", " ")|replace("/", " ")|regex_replace("\\\\s+", " ") -%}
+{% set breadcrumb_schema = {
+  "breadcrumb": {
+    "itemListElement": [
+      {
+        "item": {
+          "@id": content.absolute_url|regex_replace("/[^/]*$", ""),
+          "name": module.name_offer_parent
+        }
+      }
+    ]
+  }
+} %}
+{%- set ends_with_dollar_quote = f("a$", "b") -%}
+{%- set amp_pattern = x|regex_replace("$&", "") -%}
+{%- set back_tick_pattern = x|regex_replace("$\`", "") -%}
+{%- set backslash_replace = path|replace("\\\\", "/") -%}
+
+`;
+
 exports[`formats set.html correctly 1`] = `
   {% set my_string = "my value" 
   %}

--- a/prettier/tests/configuration/run_spec.ts
+++ b/prettier/tests/configuration/run_spec.ts
@@ -94,6 +94,13 @@ async function run_spec(dirName, options) {
       );
       expect(snapshot).toMatchSnapshot();
     });
+    if (fileName === "regex-filters.html") {
+      it(`formats ${fileName} idempotently`, async () => {
+        const firstPass = await prettyprint(input, mergedOptions);
+        const secondPass = await prettyprint(firstPass, mergedOptions);
+        expect(secondPass).toEqual(firstPass);
+      });
+    }
   });
 }
 

--- a/prettier/tests/regex-filters.html
+++ b/prettier/tests/regex-filters.html
@@ -1,0 +1,17 @@
+{%- set option_lower_and_free_of_special_chars = option.name|lower|trim|replace('&', ' ')|replace('/', ' ')|regex_replace('\\s+', ' ') -%}
+{% set breadcrumb_schema = {
+  "breadcrumb": {
+    "itemListElement": [
+      {
+        "item": {
+          "@id": content.absolute_url|regex_replace('/[^/]*$', ''),
+          "name": module.name_offer_parent
+        }
+      }
+    ]
+  }
+} %}
+{%- set ends_with_dollar_quote = f('a$', 'b') -%}
+{%- set amp_pattern = x|regex_replace('$&', '') -%}
+{%- set back_tick_pattern = x|regex_replace("$`", '') -%}
+{%- set backslash_replace = path|replace('\\', '/') -%}


### PR DESCRIPTION
Fixes https://github.com/HubSpot/prettier-plugin-hubl/issues/89

Fixes crashes and silent corruption when HubL templates use regex-like patterns in string filter arguments (e.g. regex_replace('/[^/]*$', ''), regex_replace('\\s+', ' ')).
## Problem

Two separate bugs, both unrelated to HubL `r/.../` regex literals:

1. **`unTokenize` + `replaceAll`** — After HTML formatting, restored HubL tags use `replaceAll(key, value)`. JavaScript treats `$'`, `$&`, `` $` ``, etc. in `value` as replacement patterns. A filter like `regex_replace('/[^/]*$', '')` gets corrupted before parse (e.g. `$'` becomes “text after the match”), leading to `parseSignature: expected comma after expression`.

2. **String lexer drops unknown escapes** — `_parseString` only expands `\n`, `\t`, `\r`; other `\X` sequences drop the backslash. So `'\\s+'` parses as `s+`, prints as `"\s+"`, and a second format pass becomes `"s+"` — regex patterns are stripped over time. This can also contribute to `InvalidDocError` in heavier templates.

## Solution

- **`prettier/src/index.ts`**: Use `replaceAll(key, () => value)` so restored placeholders are inserted literally.
- **`parser/src/parser/lexer.js`**: For unknown escapes, keep both `\` and the following character (`str += "\\" + this.current()`).
- **Tests**: New `prettier/tests/regex-filters.html` fixture (ticket repros + `$'`, `$&`, `` $` ``, backslash `replace`). Idempotency test (`format(format(src)) === format(src)`) scoped to that fixture.