### PR TITLE
fix: parse HubL slice syntax in subscripts

### DIFF
--- a/parser/src/parser/nodes.js
+++ b/parser/src/parser/nodes.js
@@ -93,6 +93,9 @@ export const Dict = NodeList.extend("Dict");
 export const LookupVal = Node.extend("LookupVal", {
   fields: ["target", "val"],
 });
+export const Slice = Node.extend("Slice", {
+  fields: ["start", "stop", "step"],
+});
 export const If = Node.extend("If", { fields: ["cond", "body", "else_"] });
 export const Unless = Node.extend("Unless", {
   fields: ["cond", "body", "_else"],

--- a/parser/src/parser/parser.js
+++ b/parser/src/parser/parser.js
@@ -889,18 +889,7 @@ export class Parser extends Obj {
           this.parseSignature(),
         );
       } else if (tok.type === lexer.TOKEN_LEFT_BRACKET) {
-        // Reference
-        lookup = this.parseAggregate();
-        if (lookup.children.length > 1) {
-          this.fail("invalid index");
-        }
-
-        node = new nodes.LookupVal(
-          tok.lineno,
-          tok.colno,
-          node,
-          lookup.children[0],
-        );
+        node = this.parseSubscript(node);
       } else if (tok.type === lexer.TOKEN_OPERATOR && tok.value === ".") {
         // Reference
         this.nextToken();
@@ -1328,6 +1317,63 @@ export class Parser extends Obj {
     );
 
     return new nodes.Output(name.lineno, name.colno, [node]);
+  }
+
+  parseSubscript(target) {
+    const tok = this.nextToken();
+
+    if (this.skip(lexer.TOKEN_COLON)) {
+      let stop = null;
+      const nextAfterLeadingColon = this.peekToken().type;
+      if (
+        nextAfterLeadingColon !== lexer.TOKEN_RIGHT_BRACKET &&
+        nextAfterLeadingColon !== lexer.TOKEN_COLON
+      ) {
+        stop = this.parseExpression();
+      }
+      let step = null;
+      if (this.skip(lexer.TOKEN_COLON)) {
+        if (this.peekToken().type !== lexer.TOKEN_RIGHT_BRACKET) {
+          step = this.parseExpression();
+        }
+      }
+      this.expect(lexer.TOKEN_RIGHT_BRACKET);
+      return new nodes.LookupVal(
+        tok.lineno,
+        tok.colno,
+        target,
+        new nodes.Slice(tok.lineno, tok.colno, null, stop, step),
+      );
+    }
+
+    const first = this.parseExpression();
+
+    if (this.skip(lexer.TOKEN_COLON)) {
+      let stop = null;
+      const nextAfterColon = this.peekToken().type;
+      if (
+        nextAfterColon !== lexer.TOKEN_RIGHT_BRACKET &&
+        nextAfterColon !== lexer.TOKEN_COLON
+      ) {
+        stop = this.parseExpression();
+      }
+      let step = null;
+      if (this.skip(lexer.TOKEN_COLON)) {
+        if (this.peekToken().type !== lexer.TOKEN_RIGHT_BRACKET) {
+          step = this.parseExpression();
+        }
+      }
+      this.expect(lexer.TOKEN_RIGHT_BRACKET);
+      return new nodes.LookupVal(
+        tok.lineno,
+        tok.colno,
+        target,
+        new nodes.Slice(tok.lineno, tok.colno, first, stop, step),
+      );
+    }
+
+    this.expect(lexer.TOKEN_RIGHT_BRACKET);
+    return new nodes.LookupVal(tok.lineno, tok.colno, target, first);
   }
 
   parseAggregate() {

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -274,6 +274,20 @@ function printHubl(node) {
         softline,
         "]",
       ]);
+    case "Slice": {
+      const sliceParts: Doc[] = [];
+      if (node.start != null) {
+        sliceParts.push(printHubl(node.start));
+      }
+      sliceParts.push(":");
+      if (node.stop != null) {
+        sliceParts.push(printHubl(node.stop));
+      }
+      if (node.step != null) {
+        sliceParts.push(":", printHubl(node.step));
+      }
+      return sliceParts;
+    }
     case "LookupVal":
       if (
         node.val.typename === "Literal" &&

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -3329,6 +3329,21 @@ a_var %}
 
 `;
 
+exports[`formats sliceSyntax.html correctly 1`] = `
+{% set filtered_parts = filter_names[0:loop.index]|join('/') %}
+{{ obj['key'] }}
+{{ items[:5] }}
+{{ items[0:] }}
+{{ items[::2] }}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% set filtered_parts = filter_names[0:loop.index]|join("/") %}
+{{ obj.key }}
+{{ items[:5] }}
+{{ items[0:] }}
+{{ items[::2] }}
+
+`;
+
 exports[`formats tags.html correctly 1`] = `
 {% extends "custom/page/web_page_basic/my_template.html" %}
 {% block my_sidebar %}

--- a/prettier/tests/configuration/run_spec.ts
+++ b/prettier/tests/configuration/run_spec.ts
@@ -94,7 +94,7 @@ async function run_spec(dirName, options) {
       );
       expect(snapshot).toMatchSnapshot();
     });
-    if (fileName === "regex-filters.html") {
+    if (fileName === "regex-filters.html" || fileName === "sliceSyntax.html") {
       it(`formats ${fileName} idempotently`, async () => {
         const firstPass = await prettyprint(input, mergedOptions);
         const secondPass = await prettyprint(firstPass, mergedOptions);

--- a/prettier/tests/sliceSyntax.html
+++ b/prettier/tests/sliceSyntax.html
@@ -1,0 +1,5 @@
+{% set filtered_parts = filter_names[0:loop.index]|join('/') %}
+{{ obj['key'] }}
+{{ items[:5] }}
+{{ items[0:] }}
+{{ items[::2] }}


### PR DESCRIPTION
## Problem

After a value, `[...]` in HubL/Jinja can mean either:

| Syntax | Meaning | Example |
|--------|---------|---------|
| `[expr]` | Index / key | `obj['key']`, `list[0]` |
| `[start:stop:step]` | Slice | `filter_names[0:loop.index]` |

The parser treated **every** postfix `[` as an **array literal** (`parseAggregate`), which expects comma-separated elements—not colons.

For `filter_names[0:loop.index]`:

1. Parses `0` as the first array element
2. Sees `:` and expects a comma
3. **Fails:** `parseAggregate: expected comma after expression`

## Fix

Route postfix `[` through **`parseSubscript`** instead of `parseAggregate`:

```mermaid
flowchart TD
  A["Bracket after expression"] --> B{"Leading colon?"}
  B -->|yes| C["Slice without start"]
  B -->|no| D["Parse expression"]
  D --> E{"Colon after expression?"}
  E -->|yes| F["Slice with start"]
  E -->|no| G["Index or key lookup"]
  C --> H["LookupVal and Slice node"]
  F --> H
  G --> I["LookupVal and expression"]
```

**Changes:**

| File | Change |
|------|--------|
| `parser/src/parser/nodes.js` | `Slice` node (`start`, `stop`, `step`) |
| `parser/src/parser/parser.js` | `parseSubscript()`; `parsePostfix` uses it for `[` |
| `prettier/src/printHubl.ts` | `case "Slice"` to print `:` / optional bounds |
| `prettier/tests/sliceSyntax.html` | Snapshot test for slice + index cases |

Array literals like `{% set x = [1, 2] %}` are unchanged—they still use `parseAggregate` from `parsePrimary`, not postfix subscripts.

