### PR TITLE
fix: preserve indentation for multiline dicts

### DIFF
--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -165,7 +165,7 @@ function printHubl(node) {
           closeTag(node.whiteSpace.closingTag),
         ];
       }
-      return [
+      return align(Math.max(node.colno - 3, 0), [
         openTag(node.whiteSpace.openTag),
         " set ",
         setTargets,
@@ -173,7 +173,7 @@ function printHubl(node) {
         printHubl(node.value),
         " ",
         closeTag(node.whiteSpace.openTag),
-      ];
+      ]);
     }
     case "Concat":
       return [printHubl(node.left), " ~ ", printHubl(node.right)];
@@ -263,13 +263,13 @@ function printHubl(node) {
         if (child.typename === "TemplateData") {
           return printHubl(child);
         }
-        return [
+        return align(node.colno, [
           openVar(node.whiteSpace.openTag),
           " ",
           printHubl(child),
           " ",
           closeVar(node.whiteSpace.openTag),
-        ];
+        ]);
       });
     case "NodeList":
       return node.children.map((child) => {

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -799,6 +799,68 @@ border-radius: {{ module.styles.active.corner.radius ~ "px" }};
 
 `;
 
+exports[`formats dicts.html correctly 1`] = `
+<body>
+  {% block body %}
+    <h1>Dicts</h1>
+    <p>On success they should indent properly.</p>
+  {% endblock %}
+
+
+{# a dict in a set tag that should line up #}
+{% set test_object = {
+    position: "footer",
+  defer: true
+}%}
+
+{# a dict as a param #}
+  {{ require_js(get_asset_url("../../scripts/super.hubl.js"), {
+  position: "footer",
+  defer: true
+}) }}
+
+{# One complex example with multiple objects in a macro #}
+  {{ custom_macro(
+    'string_arg',
+  {
+    second_arg_object_property: "foo",
+    bar: true
+  },
+  {
+    third_arg_object_property: "footer", baz: false }
+) }}
+</body>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<body>
+  {% block body %}
+    <h1>Dicts</h1>
+    <p>On success they should indent properly.</p>
+  {% endblock body %}
+
+  {# a dict in a set tag that should line up #}
+  {% set test_object = {
+    position: "footer",
+    defer: true
+  } %}
+
+  {# a dict as a param #}
+  {{ require_js(get_asset_url("../../scripts/super.hubl.js"), {
+    position: "footer",
+    defer: true
+  }) }}
+
+  {# One complex example with multiple objects in a macro #}
+  {{ custom_macro("string_arg", {
+    second_arg_object_property: "foo",
+    bar: true
+  }, {
+    third_arg_object_property: "footer",
+    baz: false
+  }) }}
+</body>
+
+`;
+
 exports[`formats for.html correctly 1`] = `
 {% for key, val in request.query_dict.items() %}
 {{ key }}:{{ val }}

--- a/prettier/tests/dicts.html
+++ b/prettier/tests/dicts.html
@@ -1,0 +1,30 @@
+<body>
+  {% block body %}
+    <h1>Dicts</h1>
+    <p>On success they should indent properly.</p>
+  {% endblock %}
+
+
+{# a dict in a set tag that should line up #}
+{% set test_object = {
+    position: "footer",
+  defer: true
+}%}
+
+{# a dict as a param #}
+  {{ require_js(get_asset_url("../../scripts/super.hubl.js"), {
+  position: "footer",
+  defer: true
+}) }}
+
+{# One complex example with multiple objects in a macro #}
+  {{ custom_macro(
+    'string_arg',
+  {
+    second_arg_object_property: "foo",
+    bar: true
+  },
+  {
+    third_arg_object_property: "footer", baz: false }
+) }}
+</body>


### PR DESCRIPTION
Fixes #93.

## Summary

This updates the HubL printer so multiline dicts inherit the indentation of the HubL tag that contains them. The previous printer emitted `{{ ... }}` output expressions and inline `{% set ... = ... %}` tags without aligning nested multiline docs to the enclosing tag column, so dict entries could be printed flush with the page instead of under the expression.

## Example

Input from `prettier/tests/dicts.html`:

```hubl
{# a dict in a set tag that should line up #}
{% set test_object = {
    position: "footer",
  defer: true
}%}

{# a dict as a param #}
  {{ require_js(get_asset_url("../../scripts/super.hubl.js"), {
  position: "footer",
  defer: true
}) }}
```

Formatted output:

```hubl
{# a dict in a set tag that should line up #}
{% set test_object = {
  position: "footer",
  defer: true
} %}

{# a dict as a param #}
{{ require_js(get_asset_url("../../scripts/super.hubl.js"), {
  position: "footer",
  defer: true
}) }}
```

The fixture also includes a macro call with multiple dict arguments to cover output expressions with more than one object parameter.

## Validation

```bash
npm test
npx prettier prettier/tests/dicts.html --parser hubl --plugin ./prettier/dist/src/index.js
```
