### PR TITLE
fix: make dict, ternary FunCall, and SVG path formatting idempotent

### DIFF
--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -27,7 +27,41 @@ const Token = {
   npe: (index: number) => `npe${index}_`,
   comment: (index: number) => `<!--${index}-->`,
   placeholder: (index: number) => `<!--placeholder-${index}-->`,
+  svgBlock: (index: number) => `<!--svgblock-${index}-->`,
   jsonBlock: (match: string) => `{% json_block %}${match}{% end_json_block %}`,
+};
+
+const SVG_ELEMENT_REGEX = /<svg\b[\s\S]*?<\/svg>/gim;
+
+/**
+ * Replaces entire `<svg>...</svg>` blocks with a placeholder before the HTML
+ * formatting pass so Prettier's HTML formatter never reflows their contents
+ * (notably long, multi-line `<path d="...">` data, which would otherwise be
+ * re-wrapped differently on each run and break idempotency). The original
+ * SVG is restored verbatim afterwards and wrapped in `{% preserve %}`.
+ */
+const preserveSvgElements = (input: string): string => {
+  return input.replace(SVG_ELEMENT_REGEX, (match) => {
+    const token = Token.svgBlock(tokenIndex++);
+    tokenMap.set(token, match);
+    return token;
+  });
+};
+
+const isInsidePreserveBlock = (fullText: string, matchOffset: number) => {
+  const before = fullText.slice(0, matchOffset);
+  const lastPreserve = before.lastIndexOf("{% preserve");
+  const lastEndPreserve = before.lastIndexOf("{% endpreserve");
+  return lastPreserve !== -1 && lastPreserve > lastEndPreserve;
+};
+
+const wrapSvgWithPreserve = (input: string): string => {
+  return input.replace(SVG_ELEMENT_REGEX, (match, offset, fullText) => {
+    if (isInsidePreserveBlock(fullText, offset)) {
+      return match;
+    }
+    return `{% preserve %}${match}{% endpreserve %}`;
+  });
 };
 
 const tokenMap: Map<string, string> = new Map();
@@ -154,6 +188,9 @@ const tokenize = (input: string): string => {
       input = input.replace(match, placeholderToken);
     });
   }
+
+  input = preserveSvgElements(input);
+
   tokenIndex = 0;
   return input;
 };
@@ -188,11 +225,11 @@ const parsers: Plugin["parsers"] = {
         parser: "html",
         trailingComma: "es5",
       });
+      updatedText = unTokenize(updatedText);
+      updatedText = wrapSvgWithPreserve(updatedText);
       // Find <pre> tags and add {% preserve %} wrapper
       // to tell the HubL parser to preserve formatting
-      updatedText = preserveFormatting(updatedText);
-      // Swap back HubL tags and return
-      return unTokenize(updatedText);
+      return preserveFormatting(updatedText);
     },
     locStart,
     locEnd,

--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -32,6 +32,12 @@ const Token = {
 };
 
 const SVG_ELEMENT_REGEX = /<svg\b[\s\S]*?<\/svg>/gim;
+// Same as SVG_ELEMENT_REGEX, but also captures the whitespace on the opening
+// `<svg>` tag's own line. Only used post-HTML-format (see wrapSvgWithPreserve)
+// so the correctly-computed nesting indent (e.g. one level inside a parent
+// <div>) is folded into the Preserve node's value instead of being lost.
+const SVG_ELEMENT_WITH_LEADING_WHITESPACE_REGEX =
+  /[ \t]*<svg\b[\s\S]*?<\/svg>/gim;
 
 /**
  * Replaces entire `<svg>...</svg>` blocks with a placeholder before the HTML
@@ -56,12 +62,15 @@ const isInsidePreserveBlock = (fullText: string, matchOffset: number) => {
 };
 
 const wrapSvgWithPreserve = (input: string): string => {
-  return input.replace(SVG_ELEMENT_REGEX, (match, offset, fullText) => {
-    if (isInsidePreserveBlock(fullText, offset)) {
-      return match;
-    }
-    return `{% preserve %}${match}{% endpreserve %}`;
-  });
+  return input.replace(
+    SVG_ELEMENT_WITH_LEADING_WHITESPACE_REGEX,
+    (match, offset, fullText) => {
+      if (isInsidePreserveBlock(fullText, offset)) {
+        return match;
+      }
+      return `{% preserve %}${match}{% endpreserve %}`;
+    },
+  );
 };
 
 const tokenMap: Map<string, string> = new Map();

--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -31,6 +31,12 @@ const Token = {
   jsonBlock: (match: string) => `{% json_block %}${match}{% end_json_block %}`,
 };
 
+// NOTE: nested `<svg>` elements (an `<svg>` inside another `<svg>`) are not
+// supported. This regex is lazy, so it matches from the outer `<svg` to the
+// *first* `</svg>` it finds (the inner one), leaving the outer closing tag
+// dangling and causing the HTML formatting pass to throw. This is assumed to
+// be a rare enough pattern in practice; a correct fix would need to track
+// nesting depth instead of a single regex.
 const SVG_ELEMENT_REGEX = /<svg\b[\s\S]*?<\/svg>/gim;
 // Same as SVG_ELEMENT_REGEX, but also captures the whitespace on the opening
 // `<svg>` tag's own line. Only used post-HTML-format (see wrapSvgWithPreserve)

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -79,26 +79,15 @@ const printJsonBody = (node) => {
 };
 
 /**
- * Renders a preserved `<svg>` block so the surrounding macro/block indent is
- * applied consistently, while keeping every line's indentation *relative to
- * the `<svg>` line* exactly as authored (so `<path>` stays nested one level
- * inside `<svg>`, `d="..."` one level inside `<path>`, etc).
- *
- * `value`'s first line always carries the whitespace that HTML formatting
- * computed for `<svg>` itself (folded in by `wrapSvgWithPreserve`), which
- * reflects the correct nesting depth (e.g. one level inside a parent `<div>`).
- * Every other line is still using its *original, unformatted* column
- * position, so we re-anchor each of them: the smallest indent among the
- * non-blank following lines is treated as the original `<svg>` baseline
- * (normally matching `</svg>`), and each line's offset from that baseline is
- * re-applied on top of the correctly-computed `<svg>` indent.
- *
- * Because the printer's own `indent()` builder is not re-applied per line
- * here (the whole block is a single `join(hardline, ...)`), the `<svg>`
- * indent has to be embedded as a literal prefix on every line, not just the
- * first one. This normalization is purely relative and deterministic, so
- * re-formatting the output reproduces it exactly, keeping the printer
- * idempotent.
+ * Renders a preserved `<svg>` block, keeping every line's indentation
+ * relative to `<svg>` exactly as authored (so `<path>` stays nested inside
+ * it, etc). `value`'s first line carries the correct HTML-computed `<svg>`
+ * indent (folded in by `wrapSvgWithPreserve`); every other line still has
+ * its original, unformatted column. We re-anchor those lines against their
+ * smallest shared indent (normally `</svg>`) and re-apply the offset on top
+ * of the real `<svg>` indent, embedding it literally since `indent()` isn't
+ * reapplied per line inside a single `join(hardline, ...)`. Purely relative
+ * and deterministic, so it stays idempotent across repeated formatting.
  */
 const printSvgPreserveContent = (value: string): Doc => {
   const lines = value.split("\n");

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -78,6 +78,37 @@ const printJsonBody = (node) => {
   }
 };
 
+/**
+ * Renders a preserved `<svg>` block so the surrounding macro/block indent is
+ * applied consistently. The SVG content is kept verbatim (never reflowed), so
+ * only its relative indentation is normalized: the opening tag sits at the
+ * block indent and every other line keeps its offset relative to it. Because
+ * normalization is purely relative, re-formatting the output reproduces it
+ * exactly, which keeps the printer idempotent.
+ */
+const printSvgPreserveContent = (value: string): Doc => {
+  const lines = value.split("\n");
+  const [firstLine, ...followingLines] = lines;
+  const nonEmptyFollowing = followingLines.filter(
+    (line) => line.trim().length > 0,
+  );
+  const minIndent =
+    nonEmptyFollowing.length > 0
+      ? Math.min(
+          ...nonEmptyFollowing.map(
+            (line) => line.match(/^[\t ]*/)?.[0].length ?? 0,
+          ),
+        )
+      : 0;
+  const normalizedLines = [
+    firstLine.trimStart(),
+    ...followingLines.map((line) =>
+      line.trim().length === 0 ? "" : line.slice(minIndent),
+    ),
+  ];
+  return join(hardline, normalizedLines);
+};
+
 const printForValues = (node) => {
   return join(
     ", ",
@@ -144,6 +175,9 @@ function printHubl(node) {
         return printHubl(child);
       });
     case "Preserve":
+      if (/^\s*<svg\b/i.test(node.value)) {
+        return printSvgPreserveContent(node.value);
+      }
       return node.value;
     case "Set": {
       const setTargets = join(
@@ -339,18 +373,29 @@ function printHubl(node) {
           return [op.type, " ", printHubl(op.expr)];
         }),
       ]);
-    case "FunCall":
-      return [
+    case "FunCall": {
+      const printedArguments = node.args.children.map((arg) => {
+        return printHubl(arg);
+      });
+      const hasTernaryArgument = node.args.children.some(
+        (arg) => arg.typename === "Ternary",
+      );
+      if (!hasTernaryArgument) {
+        return group([
+          printHubl(node.name),
+          "(",
+          join(", ", printedArguments),
+          ")",
+        ]);
+      }
+      return group([
         printHubl(node.name),
         "(",
-        join(
-          ", ",
-          node.args.children.map((arg) => {
-            return printHubl(arg);
-          }),
-        ),
+        indent([softline, join([",", line], printedArguments)]),
+        softline,
         ")",
-      ];
+      ]);
+    }
     case "Block":
       return [
         [
@@ -394,8 +439,8 @@ function printHubl(node) {
       ];
     }
     case "Dict": {
-      const dictParts: any[] = ["{"];
-      dictParts.push(
+      return group([
+        "{",
         indent(
           join(
             ",",
@@ -404,9 +449,9 @@ function printHubl(node) {
             }),
           ),
         ),
-      );
-      dictParts.push(hardline, "}");
-      return dictParts;
+        hardline,
+        "}",
+      ]);
     }
     case "For": {
       return [

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -80,19 +80,34 @@ const printJsonBody = (node) => {
 
 /**
  * Renders a preserved `<svg>` block so the surrounding macro/block indent is
- * applied consistently. The SVG content is kept verbatim (never reflowed), so
- * only its relative indentation is normalized: the opening tag sits at the
- * block indent and every other line keeps its offset relative to it. Because
- * normalization is purely relative, re-formatting the output reproduces it
- * exactly, which keeps the printer idempotent.
+ * applied consistently, while keeping every line's indentation *relative to
+ * the `<svg>` line* exactly as authored (so `<path>` stays nested one level
+ * inside `<svg>`, `d="..."` one level inside `<path>`, etc).
+ *
+ * `value`'s first line always carries the whitespace that HTML formatting
+ * computed for `<svg>` itself (folded in by `wrapSvgWithPreserve`), which
+ * reflects the correct nesting depth (e.g. one level inside a parent `<div>`).
+ * Every other line is still using its *original, unformatted* column
+ * position, so we re-anchor each of them: the smallest indent among the
+ * non-blank following lines is treated as the original `<svg>` baseline
+ * (normally matching `</svg>`), and each line's offset from that baseline is
+ * re-applied on top of the correctly-computed `<svg>` indent.
+ *
+ * Because the printer's own `indent()` builder is not re-applied per line
+ * here (the whole block is a single `join(hardline, ...)`), the `<svg>`
+ * indent has to be embedded as a literal prefix on every line, not just the
+ * first one. This normalization is purely relative and deterministic, so
+ * re-formatting the output reproduces it exactly, keeping the printer
+ * idempotent.
  */
 const printSvgPreserveContent = (value: string): Doc => {
   const lines = value.split("\n");
   const [firstLine, ...followingLines] = lines;
+  const svgIndent = firstLine.match(/^[\t ]*/)?.[0] ?? "";
   const nonEmptyFollowing = followingLines.filter(
     (line) => line.trim().length > 0,
   );
-  const minIndent =
+  const baselineIndent =
     nonEmptyFollowing.length > 0
       ? Math.min(
           ...nonEmptyFollowing.map(
@@ -101,10 +116,15 @@ const printSvgPreserveContent = (value: string): Doc => {
         )
       : 0;
   const normalizedLines = [
-    firstLine.trimStart(),
-    ...followingLines.map((line) =>
-      line.trim().length === 0 ? "" : line.slice(minIndent),
-    ),
+    firstLine,
+    ...followingLines.map((line) => {
+      if (line.trim().length === 0) {
+        return "";
+      }
+      const lineIndent = line.match(/^[\t ]*/)?.[0].length ?? 0;
+      const relativeOffset = Math.max(lineIndent - baselineIndent, 0);
+      return svgIndent + " ".repeat(relativeOffset) + line.trimStart();
+    }),
   ];
   return join(hardline, normalizedLines);
 };

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -1187,6 +1187,67 @@ screenshotPath: ../images/template-previews/hubdb.png
 
 `;
 
+exports[`formats idempotent-dict-ternary.html correctly 1`] = `
+{% set offersCtaLanguage = {
+  "en": "Download for free",
+  "de": "Kostenlos herunterladen",
+  "fr": "Télécharger gratuitement",
+  "es": "Descargar gratis",
+} %}
+
+{% for cta in module.offers_ctas %}
+  {% set cta_style = cta.cta_style == 'text_icon' and isLarge ? "text_icon" : "button" %}
+  {{ renderCTA(cta, loop.index == 1 ? "primary" : "secondary", "large", cta_style, "offers__cta", cta.tracking_class) }}
+{% endfor %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% set offersCtaLanguage = {
+  "en": "Download for free",
+  "de": "Kostenlos herunterladen",
+  "fr": "Télécharger gratuitement",
+  "es": "Descargar gratis"
+} %}
+
+{% for cta in module.offers_ctas %}
+{% set cta_style = cta.cta_style == "text_icon" and isLarge ? "text_icon" : "button" %}
+{{ renderCTA(
+  cta,
+  loop.index == 1 ? "primary" : "secondary",
+  "large",
+  cta_style,
+  "offers__cta",
+  cta.tracking_class
+) }}
+{% endfor %}
+
+`;
+
+exports[`formats idempotent-svg-path.html correctly 1`] = `
+{% macro renderMobileBackground() %}
+<div class="insights-layout-background-container -mobile">
+  <svg width="375" height="285" viewBox="0 0 375 285" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M543.279 662.304C536.98 666.635 529.524 668.971 521.846 669.878
+        C490.947 673.315 460.01 676.64 429.035 680.228 333.115 691.354
+        237.195 702.48 141.275 713.606 45.355 724.732"
+    />
+  </svg>
+</div>
+{% endmacro %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% macro renderMobileBackground() %}
+  <div class="insights-layout-background-container -mobile">
+    <svg width="375" height="285" viewBox="0 0 375 285" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M543.279 662.304C536.98 666.635 529.524 668.971 521.846 669.878
+        C490.947 673.315 460.01 676.64 429.035 680.228 333.115 691.354
+        237.195 702.48 141.275 713.606 45.355 724.732"
+    />
+  </svg>
+  </div>
+{% endmacro %}
+
+`;
+
 exports[`formats if.html correctly 1`] = `
 <div class="{% if true %}foo{% endif %}">
   Content

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -1237,12 +1237,12 @@ exports[`formats idempotent-svg-path.html correctly 1`] = `
 {% macro renderMobileBackground() %}
   <div class="insights-layout-background-container -mobile">
     <svg width="375" height="285" viewBox="0 0 375 285" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path
-      d="M543.279 662.304C536.98 666.635 529.524 668.971 521.846 669.878
-        C490.947 673.315 460.01 676.64 429.035 680.228 333.115 691.354
-        237.195 702.48 141.275 713.606 45.355 724.732"
-    />
-  </svg>
+      <path
+        d="M543.279 662.304C536.98 666.635 529.524 668.971 521.846 669.878
+          C490.947 673.315 460.01 676.64 429.035 680.228 333.115 691.354
+          237.195 702.48 141.275 713.606 45.355 724.732"
+      />
+    </svg>
   </div>
 {% endmacro %}
 

--- a/prettier/tests/configuration/run_spec.ts
+++ b/prettier/tests/configuration/run_spec.ts
@@ -79,6 +79,13 @@ function createTestObject(
   };
 }
 
+const IDEMPOTENCY_FIXTURES = new Set([
+  "idempotent-dict-ternary.html",
+  "idempotent-svg-path.html",
+  "set.html",
+  "ternary.html",
+]);
+
 async function run_spec(dirName, options) {
   const testObjects = fs
     .readdirSync(dirName)
@@ -94,6 +101,13 @@ async function run_spec(dirName, options) {
       );
       expect(snapshot).toMatchSnapshot();
     });
+    if (IDEMPOTENCY_FIXTURES.has(fileName)) {
+      it(`formats ${fileName} idempotently`, async () => {
+        const firstPass = await prettyprint(input, mergedOptions);
+        const secondPass = await prettyprint(firstPass, mergedOptions);
+        expect(secondPass).toBe(firstPass);
+      });
+    }
   });
 }
 

--- a/prettier/tests/idempotent-dict-ternary.html
+++ b/prettier/tests/idempotent-dict-ternary.html
@@ -1,0 +1,11 @@
+{% set offersCtaLanguage = {
+  "en": "Download for free",
+  "de": "Kostenlos herunterladen",
+  "fr": "Télécharger gratuitement",
+  "es": "Descargar gratis",
+} %}
+
+{% for cta in module.offers_ctas %}
+  {% set cta_style = cta.cta_style == 'text_icon' and isLarge ? "text_icon" : "button" %}
+  {{ renderCTA(cta, loop.index == 1 ? "primary" : "secondary", "large", cta_style, "offers__cta", cta.tracking_class) }}
+{% endfor %}

--- a/prettier/tests/idempotent-svg-path.html
+++ b/prettier/tests/idempotent-svg-path.html
@@ -1,0 +1,11 @@
+{% macro renderMobileBackground() %}
+<div class="insights-layout-background-container -mobile">
+  <svg width="375" height="285" viewBox="0 0 375 285" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M543.279 662.304C536.98 666.635 529.524 668.971 521.846 669.878
+        C490.947 673.315 460.01 676.64 429.035 680.228 333.115 691.354
+        237.195 702.48 141.275 713.606 45.355 724.732"
+    />
+  </svg>
+</div>
+{% endmacro %}


### PR DESCRIPTION
## Problem

Running `prettier --write` twice on the same HubL template should produce the same output both times (`format(format(x)) === format(x)`). Several patterns violated that, so `prettier --check` kept reporting changes even when the file was already formatted.

| Area | Symptom | Typical source |
|------|---------|----------------|
| **Dict literals** | Pass 1 adds/removes trailing commas or changes line breaks; pass 2 reverses it | `{% set lang = { "en": "...", ... , } %}` |
| **FunCall + ternary** | Argument line-breaking flips between single-line and multiline when a ternary is an argument | `renderCTA(cta, loop.index == 1 ? "primary" : "secondary", ...)` |
| **Inline SVG / path `d`** | HTML Prettier reflows multiline `d="..."` differently on each preprocess pass | Long `<path d="M... C...">` inside templates/macros |

The plugin formats HubL in two stages:

1. **Preprocess** — tokenize HubL, run stock HTML Prettier, restore tokens  
2. **Print** — parse HubL AST and print with `printHubl.ts`

Dict/ternary oscillation came from **stage 2** (unstable printer choices). SVG oscillation came from **stage 1** (HTML formatter touching path data, then the HubL printer re-indenting preserved content inconsistently).

---

## Fix

### HubL printer — stable output for dicts and ternary calls

- **`Dict`** — always print one key per line, no trailing comma on the last entry (matches parser behavior).
- **`FunCall`** — when any argument is a `Ternary`, use a fixed multiline argument layout (`indent` + `softline` / `line`) so line breaks do not flip between runs.

### Preprocess + printer — keep SVG verbatim but indentable

1. **`preserveSvgElements`** (in `tokenize`) — replace each `<svg>...</svg>` with a placeholder **before** HTML Prettier runs, so path `d` data is never reflowed.
2. **`unTokenize`** — restore real SVG markup.
3. **`wrapSvgWithPreserve`** — wrap restored SVG in `{% preserve %}...{% endpreserve %}` so the HubL parser emits a `Preserve` node (same mechanism as `<pre>`).
4. **`printSvgPreserveContent`** — print preserved SVG with `join(hardline, lines)` and normalized relative indent so macro/block `indent()` applies consistently (without re-running HTML Prettier on the SVG).

```mermaid
flowchart TD
  T[trim + tokenize] --> T1[HubL / style / script placeholders]
  T1 --> T2[preserveSvgElements → svgblock comment]
  T2 --> H[HTML Prettier]
  H --> U[unTokenize — restore SVG + HubL]
  U --> W[wrapSvgWithPreserve]
  W --> P[preserveFormatting for pre]
  P --> PARSE[HubL parse + printHubl]
```

Order matters: SVG must be restored from placeholders **before** `wrapSvgWithPreserve` can match `<svg>`, and preserve wrappers are applied **after** HTML format so HubL tags are not fed through the HTML parser.
