### PR TITLE
Fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/HubSpot/prettier-plugin-hubl.git"
+    "url": "git+https://github.com/HubSpot/prettier-plugin-hubl.git"
   },
   "author": "HubSpot, Inc.",
   "license": "Apache-2.0"


### PR DESCRIPTION
## Summary

This updates the package repository metadata from an SSH GitHub URL to the public HTTPS git URL.

## Why

The current `repository.url` points at `git+ssh://git@github.com/HubSpot/prettier-plugin-hubl.git`, which requires SSH configuration for consumers and package tooling that reads npm metadata. The package is public on GitHub, so the HTTPS git URL is the public equivalent.

## Validation

- Verified `package.json` now contains `git+https://github.com/HubSpot/prettier-plugin-hubl.git`.
- Ran `git diff --check`.
- Verified `git ls-remote https://github.com/HubSpot/prettier-plugin-hubl.git HEAD`.
- Ran `npm install --ignore-scripts --package-lock=false`.
- Ran `tsc -p parser/tsconfig.json`.
- Ran `tsc -p prettier/tsconfig.json`.
- Ran `npm pack --dry-run`.

Notes:

- `yarn install --frozen-lockfile --ignore-scripts` currently fails with `Workspaces can only be enabled in private projects`, because the root package has `workspaces` and `private: false`.
- `eslint ./parser ./prettier --ext .ts` currently fails before linting because `.eslintrc.js` is loaded as ESM under the root `type: module`.
- `node --loader ts-node/esm ./parser/tests/testConfig.ts` currently fails under Node 24 with an uncaught loader object.
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js -c ./prettier/tests/configuration/jest.config.ts --runInBand` passed 25 of 26 tests; the remaining failure is a snapshot difference for `<!doctype html>` vs `<!DOCTYPE html>`, which is unrelated to this metadata-only change and likely comes from the non-lockfile npm install path used for local validation.
