### PR TITLE
Fix SSH repository metadata to use HTTPS URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/HubSpot/prettier-plugin-hubl.git"
+    "url": "git+https://github.com/HubSpot/prettier-plugin-hubl.git"
   },
   "author": "HubSpot, Inc.",
   "license": "Apache-2.0"


### PR DESCRIPTION
## Summary

This PR fixes the SSH repository metadata in package.json to use HTTPS URL instead.

## Changes

- Changed  from  to 

## Motivation

This is a metadata-only change that ensures the repository URL in package.json uses HTTPS, which is more accessible for automated tools and CI/CD pipelines.