### PR TITLE
Jc/expressions mid attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/prettier-plugin-hubl",
-  "version": "0.3.7",
+  "version": "0.3.6",
   "main": "./prettier/dist/src/index.js",
   "type": "module",
   "private": false,
@@ -52,6 +52,5 @@
     "url": "git+ssh://git@github.com/HubSpot/prettier-plugin-hubl.git"
   },
   "author": "HubSpot, Inc.",
-  "license": "Apache-2.0",
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/prettier-plugin-hubl",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "./prettier/dist/src/index.js",
   "type": "module",
   "private": false,
@@ -52,5 +52,6 @@
     "url": "git+ssh://git@github.com/HubSpot/prettier-plugin-hubl.git"
   },
   "author": "HubSpot, Inc.",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/parser/src/parser/parser.js
+++ b/parser/src/parser/parser.js
@@ -389,7 +389,13 @@ export class Parser extends Obj {
         break;
       }
 
-      if (names.children.length > 0 && !this.skip(lexer.TOKEN_COMMA)) {
+      // HubL allows `and` as an alternative to a comma between imported
+      // names, e.g. `{% from "x" import A and B %}`.
+      if (
+        names.children.length > 0 &&
+        !this.skip(lexer.TOKEN_COMMA) &&
+        !this.skipSymbol("and")
+      ) {
         this.fail("parseFrom: expected comma", fromTok.lineno, fromTok.colno);
       }
 

--- a/prettier/src/conditionalHtmlPreservation.ts
+++ b/prettier/src/conditionalHtmlPreservation.ts
@@ -1,0 +1,416 @@
+/**
+ * Detects `{% if %}/{% else %}` blocks whose branches leave HTML tags
+ * unbalanced. The HTML formatter flattens both branches into one sequential
+ * view, which corrupts tag nesting for anything that follows — so callers
+ * replace the affected spans with opaque tokens before formatting.
+ */
+
+/** A half-open character offset range `[start, end)` into the source text. */
+export interface TextRange {
+  start: number;
+  end: number;
+}
+
+/** HTML void elements (no closing tag) — excluded from tag-balance counting. */
+const VOID_HTML_ELEMENTS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "source",
+  "track",
+  "wbr",
+]);
+
+/**
+ * Matches HubL control-flow block tags (`{% if %}`, `{% else %}`, `{% endif %}`, etc.).
+ * Used by `findIfElseBlocks` to locate if/else pairs; only `if`/`else`/`endif` are
+ * handled in the stack walk today (`elif` is matched but not yet supported).
+ */
+const HUBL_CONTROL_TAG_REGEX = /\{%-?\s*(if|elif|else|endif)\b[^%]*?-?%\}/g;
+
+/** HubL block tags (`{% ... %}`) — stripped before HTML tag-balance counting. */
+const HUBL_BLOCK_TAG_REGEX = /\{%.+?%\}/gs;
+
+/** HubL variables (`{{ ... }}`) — stripped before HTML tag-balance counting. */
+const HUBL_VARIABLE_REGEX = /\{\{.+?\}\}/gs;
+
+/** HubL comments (`{# ... #}`) — stripped before HTML tag-balance counting. */
+const HUBL_COMMENT_REGEX = /\{#.*?#\}/gs;
+
+/**
+ * Matches opening/closing HTML tags and captures the tag name.
+ * Reset `lastIndex` before each `exec` loop when reusing this regex.
+ */
+const HTML_TAG_REGEX = /<\/?([a-zA-Z][\w-]*)[^>]*>/g;
+
+/** True when a tag literal ends with `/>` (e.g. SVG `<circle />`). */
+const SELF_CLOSING_HTML_TAG_REGEX = /\/>\s*$/;
+
+/** `{% if %}` / `{% endif %}` at the start of a forward-scan slice. */
+const HUBL_IF_ENDIF_AT_START_REGEX = /^\{%-?\s*(if|endif)\b[^%]*?-?%\}/;
+
+/** Character offsets delimiting a single `{% if %}...{% else %}...{% endif %}`. */
+interface IfElseBlock {
+  start: number;
+  afterIf: number;
+  elseStart: number;
+  afterElse: number;
+  beforeEndif: number;
+  end: number;
+}
+
+const isSelfClosingHtmlTag = (tag: string): boolean => {
+  return SELF_CLOSING_HTML_TAG_REGEX.test(tag);
+};
+
+/** Removes HubL syntax so only literal HTML remains for tag-balance counting. */
+const stripHubL = (fragment: string): string =>
+  fragment
+    .replace(HUBL_BLOCK_TAG_REGEX, "")
+    .replace(HUBL_VARIABLE_REGEX, "")
+    .replace(HUBL_COMMENT_REGEX, "");
+
+/**
+ * Net open HTML tag count in `fragment`, ignoring HubL and void/self-closing
+ * elements. Positive means more opens than closes.
+ */
+const getHtmlTagBalance = (fragment: string): number => {
+  const withoutHubL = stripHubL(fragment);
+
+  let balance = 0;
+  HTML_TAG_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = HTML_TAG_REGEX.exec(withoutHubL)) !== null) {
+    const fullTag = match[0];
+    const tagName = match[1].toLowerCase();
+
+    if (VOID_HTML_ELEMENTS.has(tagName)) {
+      continue;
+    }
+
+    if (isSelfClosingHtmlTag(fullTag)) {
+      continue;
+    }
+
+    if (fullTag.startsWith("</")) {
+      balance--;
+      continue;
+    }
+
+    balance++;
+  }
+
+  return balance;
+};
+
+/** Collects top-level `{% if %}...{% else %}...{% endif %}` blocks via a stack walk. */
+const findIfElseBlocks = (text: string): IfElseBlock[] => {
+  const blocks: IfElseBlock[] = [];
+  const stack: Array<{
+    start: number;
+    afterIf: number;
+    elseStart: number | null;
+    afterElse: number | null;
+  }> = [];
+
+  HUBL_CONTROL_TAG_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = HUBL_CONTROL_TAG_REGEX.exec(text)) !== null) {
+    const tagType = match[1];
+    const tagStart = match.index;
+    const tagEnd = tagStart + match[0].length;
+
+    if (tagType === "if") {
+      stack.push({
+        start: tagStart,
+        afterIf: tagEnd,
+        elseStart: null,
+        afterElse: null,
+      });
+      continue;
+    }
+
+    if (tagType === "else" && stack.length > 0) {
+      const current = stack[stack.length - 1];
+      if (current.elseStart === null) {
+        current.elseStart = tagStart;
+        current.afterElse = tagEnd;
+      }
+      continue;
+    }
+
+    if (tagType === "endif" && stack.length > 0) {
+      const current = stack.pop();
+      if (
+        !current ||
+        current.elseStart === null ||
+        current.afterElse === null
+      ) {
+        continue;
+      }
+
+      blocks.push({
+        start: current.start,
+        afterIf: current.afterIf,
+        elseStart: current.elseStart,
+        afterElse: current.afterElse,
+        beforeEndif: tagStart,
+        end: tagEnd,
+      });
+    }
+  }
+
+  return blocks;
+};
+
+/**
+ * Walks HTML tags before `ifStart` and returns the offset of the outermost
+ * still-unclosed open tag. Falls back to `ifStart` when the stack is empty.
+ */
+const findOuterUnclosedOpenStart = (text: string, ifStart: number): number => {
+  const stack: number[] = [];
+  const before = text.slice(0, ifStart);
+  HTML_TAG_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = HTML_TAG_REGEX.exec(before)) !== null) {
+    const tag = match[0];
+    const tagName = match[1].toLowerCase();
+
+    if (VOID_HTML_ELEMENTS.has(tagName) || isSelfClosingHtmlTag(tag)) {
+      continue;
+    }
+
+    if (tag.startsWith("</")) {
+      stack.pop();
+      continue;
+    }
+
+    stack.push(match.index);
+  }
+
+  return stack[0] ?? ifStart;
+};
+
+/**
+ * Fallback when forward scanning cannot resync tag balance: walk to the
+ * matching close of the root tag opened at `openStart`.
+ */
+const findContainerCloseEnd = (text: string, openStart: number): number => {
+  const openMatch = text.slice(openStart).match(/^<([a-zA-Z][\w-]*)[^>]*>/);
+  if (!openMatch) {
+    return openStart;
+  }
+
+  const rootTag = openMatch[1].toLowerCase();
+  let depth = 1;
+  let index = openStart + openMatch[0].length;
+
+  while (index < text.length) {
+    const remaining = text.slice(index);
+
+    if (/^\s+/.test(remaining)) {
+      index += remaining.match(/^\s+/)![0].length;
+      continue;
+    }
+
+    if (remaining.startsWith("{#")) {
+      const commentEnd = remaining.indexOf("#}");
+      index += commentEnd === -1 ? 2 : commentEnd + 2;
+      continue;
+    }
+
+    if (remaining.startsWith("{%")) {
+      const tagEnd = remaining.indexOf("%}");
+      index += tagEnd === -1 ? 2 : tagEnd + 2;
+      continue;
+    }
+
+    if (remaining.startsWith("{{")) {
+      const expressionEnd = remaining.indexOf("}}");
+      index += expressionEnd === -1 ? 2 : expressionEnd + 2;
+      continue;
+    }
+
+    const tagMatch = remaining.match(/^<\/?([a-zA-Z][\w-]*)[^>]*>/);
+    if (!tagMatch) {
+      index++;
+      continue;
+    }
+
+    const tag = tagMatch[0];
+    const tagName = tagMatch[1].toLowerCase();
+
+    if (
+      !VOID_HTML_ELEMENTS.has(tagName) &&
+      !(tag.startsWith("<") && !tag.startsWith("</") && isSelfClosingHtmlTag(tag))
+    ) {
+      if (tag.startsWith("</") && tagName === rootTag) {
+        depth--;
+        if (depth === 0) {
+          return index + tag.length;
+        }
+      } else if (!tag.startsWith("</") && tagName === rootTag) {
+        depth++;
+      }
+    }
+
+    index += tag.length;
+  }
+
+  return text.length;
+};
+
+/**
+ * Scans forward after a divergent if/else block until HTML tag balance
+ * resyncs. `ifDepth` ensures a later unrelated `{% if %}` whose body
+ * happens to bring balance to zero mid-block does not end the range early.
+ */
+const findPreserveEnd = (
+  text: string,
+  fromIndex: number,
+  preserveStart: number,
+): number => {
+  let balance = getHtmlTagBalance(text.slice(preserveStart, fromIndex));
+  let ifDepth = 0;
+  let index = fromIndex;
+
+  while (index < text.length && (balance > 0 || ifDepth > 0)) {
+    const remaining = text.slice(index);
+
+    if (/^\s+/.test(remaining)) {
+      index += remaining.match(/^\s+/)![0].length;
+      continue;
+    }
+
+    if (remaining.startsWith("{#")) {
+      const commentEnd = remaining.indexOf("#}");
+      index += commentEnd === -1 ? 2 : commentEnd + 2;
+      continue;
+    }
+
+    const controlTagMatch = remaining.match(HUBL_IF_ENDIF_AT_START_REGEX);
+    if (controlTagMatch) {
+      if (controlTagMatch[1] === "if") {
+        ifDepth++;
+      } else {
+        ifDepth = Math.max(0, ifDepth - 1);
+      }
+      index += controlTagMatch[0].length;
+      continue;
+    }
+
+    if (remaining.startsWith("{%")) {
+      const tagEnd = remaining.indexOf("%}");
+      index += tagEnd === -1 ? 2 : tagEnd + 2;
+      continue;
+    }
+
+    if (remaining.startsWith("{{")) {
+      const expressionEnd = remaining.indexOf("}}");
+      index += expressionEnd === -1 ? 2 : expressionEnd + 2;
+      continue;
+    }
+
+    const tagMatch = remaining.match(/^<\/?[a-zA-Z][^>]*>/);
+    if (tagMatch) {
+      const tag = tagMatch[0];
+      const tagNameMatch = tag.match(/<\/?([a-zA-Z][\w-]*)/);
+      const tagName = tagNameMatch?.[1].toLowerCase() ?? "";
+
+      if (
+        !VOID_HTML_ELEMENTS.has(tagName) &&
+        !(tag.startsWith("<") && !tag.startsWith("</") && isSelfClosingHtmlTag(tag))
+      ) {
+        if (tag.startsWith("</")) {
+          balance--;
+        } else {
+          balance++;
+        }
+      }
+
+      index += tag.length;
+      continue;
+    }
+
+    index++;
+  }
+
+  if (balance > 0) {
+    return findContainerCloseEnd(text, preserveStart);
+  }
+
+  return index;
+};
+
+/** Merges overlapping ranges so each character is covered at most once. */
+const mergeOverlappingRanges = (ranges: TextRange[]): TextRange[] => {
+  if (ranges.length === 0) {
+    return [];
+  }
+
+  const sorted = [...ranges].sort((left, right) => left.start - right.start);
+  const merged: TextRange[] = [sorted[0]];
+
+  for (const range of sorted.slice(1)) {
+    const last = merged[merged.length - 1];
+    if (range.start <= last.end) {
+      last.end = Math.max(last.end, range.end);
+    } else {
+      merged.push(range);
+    }
+  }
+
+  return merged;
+};
+
+/**
+ * Returns text spans that must be preserved verbatim because an
+ * `{% if %}/{% else %}` pair leaves HTML tags unbalanced across branches.
+ *
+ * @param input - Source template text before tokenization.
+ * @param shouldSkip - Optional predicate; when it returns true for a block's
+ *   start offset, that block is ignored (e.g. already inside `{% preserve %}`).
+ * @returns Non-overlapping ranges to replace with opaque placeholders.
+ */
+export const findConditionalPreserveRanges = (
+  input: string,
+  shouldSkip: (offset: number) => boolean = () => false,
+): TextRange[] => {
+  const blocks = findIfElseBlocks(input);
+  const preserveRanges: TextRange[] = [];
+
+  for (const block of blocks) {
+    if (shouldSkip(block.start)) {
+      continue;
+    }
+
+    const ifBranch = input.slice(block.afterIf, block.elseStart);
+    const elseBranch = input.slice(block.afterElse, block.beforeEndif);
+    const ifBalance = getHtmlTagBalance(ifBranch);
+    const elseBalance = getHtmlTagBalance(elseBranch);
+
+    // Balanced branches are safe — the HTML formatter's flattened view
+    // resyncs to the same depth regardless of which branch is "real".
+    if (ifBalance === 0 && elseBalance === 0) {
+      continue;
+    }
+
+    const preserveStart = findOuterUnclosedOpenStart(input, block.start);
+    preserveRanges.push({
+      start: preserveStart,
+      end: findPreserveEnd(input, block.end, preserveStart),
+    });
+  }
+
+  return mergeOverlappingRanges(preserveRanges);
+};

--- a/prettier/src/index.ts
+++ b/prettier/src/index.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "prettier";
 import synchronizedPrettier from "@prettier/sync";
 import { parse } from "hubl-parser";
+import { findConditionalPreserveRanges } from "./conditionalHtmlPreservation.js";
 import printers from "./printHubl.js";
 
 const languages = [
@@ -28,6 +29,7 @@ const Token = {
   comment: (index: number) => `<!--${index}-->`,
   placeholder: (index: number) => `<!--placeholder-${index}-->`,
   svgBlock: (index: number) => `<!--svgblock-${index}-->`,
+  conditionalBlock: (index: number) => `<!--conditionalblock-${index}-->`,
   jsonBlock: (match: string) => `{% json_block %}${match}{% end_json_block %}`,
 };
 
@@ -80,6 +82,7 @@ const wrapSvgWithPreserve = (input: string): string => {
 };
 
 const tokenMap: Map<string, string> = new Map();
+const conditionalBlockTokens: Set<string> = new Set();
 let tokenIndex = 0;
 
 const lookupDuplicateNestedToken = (match) => {
@@ -94,7 +97,26 @@ const lookupDuplicateNestedToken = (match) => {
 const withLead = (regex: RegExp) =>
   new RegExp(/(:\s*)?/.source + `(${regex.source})`, "gms");
 
+const applyConditionalPreserveTokens = (input: string): string => {
+  const preserveRanges = findConditionalPreserveRanges(input, (offset) =>
+    isInsidePreserveBlock(input, offset),
+  ).sort((left, right) => right.start - left.start);
+
+  let output = input;
+  for (const range of preserveRanges) {
+    const segment = output.slice(range.start, range.end);
+    const token = Token.conditionalBlock(tokenIndex++);
+    tokenMap.set(token, segment);
+    conditionalBlockTokens.add(token);
+    output = output.slice(0, range.start) + token + output.slice(range.end);
+  }
+
+  return output;
+};
+
 const tokenize = (input: string): string => {
+  input = applyConditionalPreserveTokens(input);
+
   const COMMENT_REGEX = /{#.*?#}/gms;
   const HUBL_TAG_REGEX = /({%.+?%})/gs;
   const LINE_BREAK_REGEX = /[\r\n]+/gm;
@@ -211,10 +233,16 @@ const tokenize = (input: string): string => {
 };
 
 const unTokenize = (input: string) => {
-  tokenMap.forEach((value, key) => {
-    input = input.replaceAll(key, () => value);
-  });
+  Array.from(tokenMap.entries())
+    .reverse()
+    .forEach(([key, value]) => {
+      const restoredValue = conditionalBlockTokens.has(key)
+        ? `{% preserve %}${value}{% endpreserve %}`
+        : value;
+      input = input.replaceAll(key, () => restoredValue);
+    });
   tokenMap.clear();
+  conditionalBlockTokens.clear();
   return input;
 };
 

--- a/prettier/src/printHubl.ts
+++ b/prettier/src/printHubl.ts
@@ -192,7 +192,7 @@ function printHubl(node) {
       const setTargets = join(
         ", ",
         node.targets.map((target) => {
-          return target.value;
+          return printHubl(target);
         }),
       );
       if (node.body) {
@@ -306,13 +306,16 @@ function printHubl(node) {
         if (child.typename === "TemplateData") {
           return printHubl(child);
         }
-        return [
+        // `node.colno` is `{{`'s column after HTML formatting; align by it
+        // so multi-line breaks keep surrounding HTML indentation, not just
+        // HubL block nesting.
+        return align(Math.max(node.colno, 0), [
           openVar(node.whiteSpace.openTag),
           " ",
           printHubl(child),
           " ",
           closeVar(node.whiteSpace.openTag),
-        ];
+        ]);
       });
     case "NodeList":
       return node.children.map((child) => {

--- a/prettier/tests/__snapshots__/run_tests.js.snap
+++ b/prettier/tests/__snapshots__/run_tests.js.snap
@@ -600,6 +600,106 @@ templateType: none
 
 `;
 
+exports[`formats conditional-html-wrapper.html correctly 1`] = `
+{% macro renderSection(indexMap) %}
+  <section class="section-container">
+    <div class="page-width">
+      <h2 class="section-title">{{ module.title }}</h2>
+
+      {% if isSimple %}
+        <div class="section-single">
+      {% else %}
+        <div class="section-tabs tabs">
+          <div class="section-tab-control tab-control">
+            <ul class="section-tab-list tab-list" role="tablist">
+              {% for tab in module.tabs %}
+                <li class="tab-item">
+                  <button class="tab-button" role="tab">{{ tab.label }}</button>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+      {% endif %}
+
+      <div class="section-tab-group tab-group">
+        shared content
+      </div>
+    </div>
+  </section>
+{% endmacro %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% macro renderSection(indexMap) %}
+  <section class="section-container">
+    <div class="page-width">
+      <h2 class="section-title">{{ module.title }}</h2>
+
+      {% if isSimple %}
+        <div class="section-single">
+      {% else %}
+        <div class="section-tabs tabs">
+          <div class="section-tab-control tab-control">
+            <ul class="section-tab-list tab-list" role="tablist">
+              {% for tab in module.tabs %}
+                <li class="tab-item">
+                  <button class="tab-button" role="tab">{{ tab.label }}</button>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+      {% endif %}
+
+      <div class="section-tab-group tab-group">
+        shared content
+      </div>
+    </div>
+  </section>
+{% endmacro %}
+
+`;
+
+exports[`formats conditional-html-wrapper-closing.html correctly 1`] = `
+{% macro renderCard(item) %}
+  {% set use_wrapper = item.use_wrapper %}
+  {% set show_link = item.show_link or false %}
+
+  {% if use_wrapper or show_link %}
+    <div class="card-wrapper">
+  {% else %}
+    <a class="card-link" href="{{ item.url }}">
+  {% endif %}
+    <div class="card-content">
+      <h3 class="card-title">{{ item.title }}</h3>
+      <p class="card-description">{{ item.description }}</p>
+    </div>
+  {% if use_wrapper or show_link %}
+    </div>
+  {% else %}
+    </a>
+  {% endif %}
+{% endmacro %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% macro renderCard(item) %}
+  {% set use_wrapper = item.use_wrapper %}
+  {% set show_link = item.show_link or false %}
+
+  {% if use_wrapper or show_link %}
+    <div class="card-wrapper">
+  {% else %}
+    <a class="card-link" href="{{ item.url }}">
+  {% endif %}
+    <div class="card-content">
+      <h3 class="card-title">{{ item.title }}</h3>
+      <p class="card-description">{{ item.description }}</p>
+    </div>
+  {% if use_wrapper or show_link %}
+    </div>
+  {% else %}
+    </a>
+  {% endif %}
+{% endmacro %}
+
+`;
+
 exports[`formats contact.html correctly 1`] = `
 <!--
   templateType: page
@@ -807,6 +907,15 @@ exports[`formats for.html correctly 1`] = `
 {% for key, val in request.query_dict.items() %}
 {{ key }}:{{ val }}
 {% endfor %}
+
+`;
+
+exports[`formats from-import-and-separator.html correctly 1`] = `
+{% from "macros/component-a.html" import ComponentA and ComponentB %}
+{% from "macros/helper.html" import HelperMacro %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% from "macros/component-a.html" import ComponentA, ComponentB %}
+{% from "macros/helper.html" import HelperMacro %}
 
 `;
 
@@ -1893,6 +2002,73 @@ What is this element?
 <script>
   let anoter_module_{{ name }} = document.getElementById("hs_cos_wrapper_{{ name }}");
 </script>
+
+`;
+
+exports[`formats namespace-attribute-assignment.html correctly 1`] = `
+{%- macro findMatchingOption(value, options) -%}
+  {%- set normalized_value = value|lower|trim -%}
+  {%- set ns = namespace(found=false) -%}
+
+  {%- for option in options -%}
+    {%- if ns.found == false -%}
+      {%- set normalized_option = option.name|lower|trim|replace('&', ' ')|replace('/', ' ')|regex_replace('\\\\s+', ' ') -%}
+      {%- if normalized_option == normalized_value -%}
+        {%- set ns.found = option.name -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {{ ns.found }}
+{%- endmacro -%}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{%- macro findMatchingOption(value, options) -%}
+  {%- set normalized_value = value|lower|trim -%}
+  {%- set ns = namespace(found=false) -%}
+
+  {%- for option in options -%}
+  {%- if ns.found == false -%}
+    {%- set normalized_option = option.name|lower|trim|replace("&", " ")|replace("/", " ")|regex_replace("\\\\s+", " ") -%}
+    {%- if normalized_option == normalized_value -%}
+      {%- set ns.found = option.name -%}
+    {%- endif -%}
+  {%- endif -%}
+  {%- endfor -%}
+
+  {{ ns.found }}
+{%- endmacro -%}
+
+`;
+
+exports[`formats nested-multiline-funcall.html correctly 1`] = `
+{% if showContent %}
+  <div class="container">
+    <div class="item-list">
+      {% for item in module.items %}
+      {% set item_style = item.style == "icon" and isLarge ? "icon" : "button" %}
+      {{ renderItem(item, loop.index == 1 ? "primary" : "secondary", "large", item_style, "item", item.class_name) }}
+      {% endfor %}
+    </div>
+  </div>
+{% endif %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% if showContent %}
+  <div class="container">
+    <div class="item-list">
+      {% for item in module.items %}
+      {% set item_style = item.style == "icon" and isLarge ? "icon" : "button" %}
+      {{ renderItem(
+        item,
+        loop.index == 1 ? "primary" : "secondary",
+        "large",
+        item_style,
+        "item",
+        item.class_name
+      ) }}
+      {% endfor %}
+    </div>
+  </div>
+{% endif %}
 
 `;
 
@@ -3478,6 +3654,56 @@ exports[`formats sliceSyntax.html correctly 1`] = `
 {{ items[:5] }}
 {{ items[0:] }}
 {{ items[::2] }}
+
+`;
+
+exports[`formats svg-nested-hubl-expression.html correctly 1`] = `
+<div class="progress" data-value="{{ item.value }}">
+  <svg viewBox="0 0 32 32">
+    <circle
+      class="progress-circle"
+      style="stroke-dasharray: {{ item.value }} 100"
+    ></circle>
+  </svg>
+</div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div class="progress" data-value="{{ item.value }}">
+  <svg viewBox="0 0 32 32">
+    <circle
+      class="progress-circle"
+      style="stroke-dasharray: {{ item.value }} 100"
+    ></circle>
+  </svg>
+</div>
+
+`;
+
+exports[`formats svg-own-tag-hubl-expression.html correctly 1`] = `
+<div class="hero">
+  <svg
+    class="hero-background -{{ module.theme }}"
+    width="1112"
+    height="1013"
+    viewBox="0 0 1112 1013"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M0 0h1112v1013H0z" fill="currentColor" />
+  </svg>
+</div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div class="hero">
+  <svg
+    class="hero-background -{{ module.theme }}"
+    width="1112"
+    height="1013"
+    viewBox="0 0 1112 1013"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M0 0h1112v1013H0z" fill="currentColor" />
+  </svg>
+</div>
 
 `;
 

--- a/prettier/tests/conditional-html-wrapper-closing.html
+++ b/prettier/tests/conditional-html-wrapper-closing.html
@@ -1,0 +1,19 @@
+{% macro renderCard(item) %}
+  {% set use_wrapper = item.use_wrapper %}
+  {% set show_link = item.show_link or false %}
+
+  {% if use_wrapper or show_link %}
+    <div class="card-wrapper">
+  {% else %}
+    <a class="card-link" href="{{ item.url }}">
+  {% endif %}
+    <div class="card-content">
+      <h3 class="card-title">{{ item.title }}</h3>
+      <p class="card-description">{{ item.description }}</p>
+    </div>
+  {% if use_wrapper or show_link %}
+    </div>
+  {% else %}
+    </a>
+  {% endif %}
+{% endmacro %}

--- a/prettier/tests/conditional-html-wrapper.html
+++ b/prettier/tests/conditional-html-wrapper.html
@@ -1,0 +1,26 @@
+{% macro renderSection(indexMap) %}
+  <section class="section-container">
+    <div class="page-width">
+      <h2 class="section-title">{{ module.title }}</h2>
+
+      {% if isSimple %}
+        <div class="section-single">
+      {% else %}
+        <div class="section-tabs tabs">
+          <div class="section-tab-control tab-control">
+            <ul class="section-tab-list tab-list" role="tablist">
+              {% for tab in module.tabs %}
+                <li class="tab-item">
+                  <button class="tab-button" role="tab">{{ tab.label }}</button>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+      {% endif %}
+
+      <div class="section-tab-group tab-group">
+        shared content
+      </div>
+    </div>
+  </section>
+{% endmacro %}

--- a/prettier/tests/configuration/run_spec.ts
+++ b/prettier/tests/configuration/run_spec.ts
@@ -86,6 +86,13 @@ const IDEMPOTENCY_FIXTURES = new Set([
   "ternary.html",
   "regex-filters.html",
   "sliceSyntax.html",
+  "svg-nested-hubl-expression.html",
+  "svg-own-tag-hubl-expression.html",
+  "namespace-attribute-assignment.html",
+  "conditional-html-wrapper.html",
+  "conditional-html-wrapper-closing.html",
+  "from-import-and-separator.html",
+  "nested-multiline-funcall.html",
 ]);
 
 async function run_spec(dirName, options) {

--- a/prettier/tests/from-import-and-separator.html
+++ b/prettier/tests/from-import-and-separator.html
@@ -1,0 +1,2 @@
+{% from "macros/component-a.html" import ComponentA and ComponentB %}
+{% from "macros/helper.html" import HelperMacro %}

--- a/prettier/tests/namespace-attribute-assignment.html
+++ b/prettier/tests/namespace-attribute-assignment.html
@@ -1,0 +1,15 @@
+{%- macro findMatchingOption(value, options) -%}
+  {%- set normalized_value = value|lower|trim -%}
+  {%- set ns = namespace(found=false) -%}
+
+  {%- for option in options -%}
+    {%- if ns.found == false -%}
+      {%- set normalized_option = option.name|lower|trim|replace('&', ' ')|replace('/', ' ')|regex_replace('\\s+', ' ') -%}
+      {%- if normalized_option == normalized_value -%}
+        {%- set ns.found = option.name -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {{ ns.found }}
+{%- endmacro -%}

--- a/prettier/tests/nested-multiline-funcall.html
+++ b/prettier/tests/nested-multiline-funcall.html
@@ -1,0 +1,10 @@
+{% if showContent %}
+  <div class="container">
+    <div class="item-list">
+      {% for item in module.items %}
+      {% set item_style = item.style == "icon" and isLarge ? "icon" : "button" %}
+      {{ renderItem(item, loop.index == 1 ? "primary" : "secondary", "large", item_style, "item", item.class_name) }}
+      {% endfor %}
+    </div>
+  </div>
+{% endif %}

--- a/prettier/tests/svg-nested-hubl-expression.html
+++ b/prettier/tests/svg-nested-hubl-expression.html
@@ -1,0 +1,8 @@
+<div class="progress" data-value="{{ item.value }}">
+  <svg viewBox="0 0 32 32">
+    <circle
+      class="progress-circle"
+      style="stroke-dasharray: {{ item.value }} 100"
+    ></circle>
+  </svg>
+</div>

--- a/prettier/tests/svg-own-tag-hubl-expression.html
+++ b/prettier/tests/svg-own-tag-hubl-expression.html
@@ -1,0 +1,12 @@
+<div class="hero">
+  <svg
+    class="hero-background -{{ module.theme }}"
+    width="1112"
+    height="1013"
+    viewBox="0 0 1112 1013"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M0 0h1112v1013H0z" fill="currentColor" />
+  </svg>
+</div>


### PR DESCRIPTION
## Problem

| Area | Symptom | Typical source |
| --- | --- | --- |
| **SVG + inline HubL** | `{{ ... }}` inside `<svg>` replaced with literal `npe0_`, `npe1_`, etc. | `style="stroke-dasharray: {{ item.value }} 100"` inside `<circle>` |
| **Conditional HTML wrappers** | HTML parse error: unexpected closing tag | `{% if %}<div>{% else %}<a>{% endif %}` with shared content + conditional close |
| **`{% set ns.attr %}`** | `InvalidDocError: Unexpected doc 'undefined'` | `{%- set ns.found = option.name -%}` |
| **`{% from %} import A and B`** | `parseFrom: expected comma` | `{% from "..." import ComponentA and ComponentB %}` |
| **Multi-line `{{ macro(...) }}`** | Continuation lines indented too far left | `{{ renderItem(...) }}` nested inside `<div>` + `{% for %}` |

The plugin formats HubL in two stages:

1. **Preprocess** — tokenize HubL/HTML, run stock HTML Prettier, restore tokens
2. **Print** — parse HubL AST and print with `printHubl.ts`

SVG `npe*_` corruption and conditional-wrapper failures came from **stage 1** (token restore order and HTML formatter seeing invalid flattened markup). Namespace `set`, import parsing, and macro-call indentation came from **stage 2** (parser + printer gaps).

---

## Fix

### Preprocess — restore nested placeholders in the right order

- **`unTokenize`** — restore tokens in **reverse insertion order** so outer tokens (e.g. `svgBlock`) unwrap before inner `npe*_` placeholders they contain are needed again.

### Preprocess — preserve divergent conditional HTML wrappers

HubL `{% if %}/{% else %}` is invisible to the HTML formatter, which flattens both branches. When either branch leaves HTML tags unbalanced, the formatter's view diverges and later markup breaks.

1. **`findConditionalPreserveRanges`** (new `conditionalHtmlPreservation.ts`) — detect `{% if %}...{% else %}...{% endif %}` spans where either branch has non-zero HTML tag balance. **This is the biggest change of this PR.**
2. Expand preserve range backward to the outermost unclosed open tag and forward until balance resyncs (with `ifDepth` so a later closing `{% if %}` block doesn't end the range too early)
3. **`applyConditionalPreserveTokens`** — replace those spans with opaque `conditionalBlock` tokens before HTML formatting
4. **`unTokenize`** — restore them wrapped in `{% preserve %}...{% endpreserve %}`

```mermaid
flowchart TD
  T[trim + tokenize] --> C[applyConditionalPreserveTokens]
  C --> T1[HubL / style / script / npe placeholders]
  T1 --> T2[preserveSvgElements → svgblock comment]
  T2 --> H[HTML Prettier]
  H --> U[unTokenize — reverse order + preserve wrappers]
  U --> W[wrapSvgWithPreserve]
  W --> P[preserveFormatting for pre]
  P --> PARSE[HubL parse + printHubl]
```

Order matters: conditional blocks are tokenized **before** HTML format; SVG blocks are tokenized **after** inline HubL in attributes; `unTokenize` runs in reverse so nested `npe*_` inside SVG placeholders restore correctly.

### HubL printer — namespace `{% set %}` targets

- **`Set`** — print assignment targets via `printHubl(target)` instead of `target.value`, so dotted/member targets (`ns.found`) print correctly instead of `undefined`.

### HubL printer — multi-line `{{ }}` indentation

- **`Output`** — align by `node.colno` (the `{{` column after HTML formatting) so multi-line function calls keep surrounding HTML indentation, not just HubL block nesting depth.

### HubL parser — `and` as import separator

- **`parseFrom`** — accept `and` as an alternative to a comma between imported names (valid HubL syntax used across multiple templates).
